### PR TITLE
Update go-build

### DIFF
--- a/plugins/go-build/bin/go-build
+++ b/plugins/go-build/bin/go-build
@@ -251,7 +251,7 @@ install_linux_32bit() {
     if [ "$(uname -s)" = "Linux" ]; then
         local arch="$(uname -m)"
 
-        if [ $arch = "i386" ] || [ $arch = 'i686']; then
+        if [ $arch = "i386" ] || [ $arch = 'i686' ]; then
           install_package_using "tarball" 1 "$@"
         fi
     fi


### PR DESCRIPTION
Fix bash test to prevent install error : 

```
/home/username/.goenv/plugins/go-build/bin/go-build: line 254: [: missing `]'
```