### PR TITLE
Cleanup pyenv references

### DIFF
--- a/plugins/go-build/README.md
+++ b/plugins/go-build/README.md
@@ -1,4 +1,4 @@
-# python-build
+# go-build
 
 go-build is a [goenv](https://github.com/syndbg/goenv) plugin that
 provides a `goenv install` command to compile and install different versions
@@ -51,7 +51,6 @@ Or, if you would like to install the latest development release:
 
     brew install --HEAD goenv
 
-
 ## Usage
 
 Before you begin, you should ensure that your build environment has the proper
@@ -64,86 +63,86 @@ exact name of the version you want to install. For example,
 
     goenv install 2.7.4
 
-Python versions will be installed into a directory of the same name under
-`~/.pyenv/versions`.
+Golang versions will be installed into a directory of the same name under
+`~/.goenv/versions`.
 
-To see a list of all available Python versions, run `pyenv install --list`. You
-may also tab-complete available Python versions if your pyenv installation is
+To see a list of all available Golang versions, run `goenv install --list`. You
+may also tab-complete available Golang versions if your goenv installation is
 properly configured.
 
-### Using `python-build` standalone
+### Using `go-build` standalone
 
-If you have installed python-build as a standalone program, you can use the
-`python-build` command to compile and install Python versions into specific
+If you have installed go-build as a standalone program, you can use the
+`gp-build` command to compile and install Golang versions into specific
 locations.
 
-Run the `python-build` command with the exact name of the version you want to
+Run the `go-build` command with the exact name of the version you want to
 install and the full path where you want to install it. For example,
 
-    python-build 2.7.4 ~/local/python-2.7.4
+    go-build 1.6.2 ~/local/goenv-1.6.2
 
-To see a list of all available Python versions, run `python-build --definitions`.
+To see a list of all available Golang versions, run `go-build --definitions`.
 
-Pass the `-v` or `--verbose` flag to `python-build` as the first argument to see
+Pass the `-v` or `--verbose` flag to `go-build` as the first argument to see
 what's happening under the hood.
 
 ### Custom definitions
 
-Both `pyenv install` and `python-build` accept a path to a custom definition file
+Both `goenv install` and `go-build` accept a path to a custom definition file
 in place of a version name. Custom definitions let you develop and install
-versions of Python that are not yet supported by python-build.
+versions of Golang that are not yet supported by go-build.
 
-See the [python-build built-in definitions](https://github.com/yyuu/pyenv/tree/master/plugins/python-build/share/python-build) as a starting point for
+See the [go-build built-in definitions](https://github.com/syndbg/goenv/tree/master/plugins/go-build/share/go-build) as a starting point for
 custom definition files.
 
-[definitions]: https://github.com/yyuu/pyenv/tree/master/plugins/python-build/share/python-build
+[definitions]: https://github.com/syndbg/goenv/tree/master/plugins/go-build/share/go-build
 
 ### Special environment variables
 
 You can set certain environment variables to control the build process.
 
-* `TMPDIR` sets the location where python-build stores temporary files.
-* `PYTHON_BUILD_BUILD_PATH` sets the location in which sources are downloaded and
+* `TMPDIR` sets the location where go-build stores temporary files.
+* `GO_BUILD_BUILD_PATH` sets the location in which sources are downloaded and
   built. By default, this is a subdirectory of `TMPDIR`.
-* `PYTHON_BUILD_CACHE_PATH`, if set, specifies a directory to use for caching
+* `GO_BUILD_CACHE_PATH`, if set, specifies a directory to use for caching
   downloaded package files.
-* `PYTHON_BUILD_MIRROR_URL` overrides the default mirror URL root to one of your
+* `GO_BUILD_MIRROR_URL` overrides the default mirror URL root to one of your
   choosing.
-* `PYTHON_BUILD_SKIP_MIRROR`, if set, forces python-build to download packages from
+* `GO_BUILD_SKIP_MIRROR`, if set, forces go-build to download packages from
   their original source URLs instead of using a mirror.
-* `PYTHON_BUILD_ROOT` overrides the default location from where build definitions
-  in `share/python-build/` are looked up.
-* `PYTHON_BUILD_DEFINITIONS` can be a list of colon-separated paths that get
+* `GO_BUILD_ROOT` overrides the default location from where build definitions
+  in `share/go-build/` are looked up.
+* `GO_BUILD_DEFINITIONS` can be a list of colon-separated paths that get
   additionally searched when looking up build definitions.
 * `CC` sets the path to the C compiler.
-* `PYTHON_CFLAGS` lets you pass additional options to the default `CFLAGS`. Use
+* `GO_CFLAGS` lets you pass additional options to the default `CFLAGS`. Use
   this to override, for instance, the `-O3` option.
 * `CONFIGURE_OPTS` lets you pass additional options to `./configure`.
 * `MAKE` lets you override the command to use for `make`. Useful for specifying
   GNU make (`gmake`) on some systems.
 * `MAKE_OPTS` (or `MAKEOPTS`) lets you pass additional options to `make`.
 * `MAKE_INSTALL_OPTS` lets you pass additional options to `make install`.
-* `PYTHON_CONFIGURE_OPTS` and `PYTHON_MAKE_OPTS` and `PYTHON_MAKE_INSTALL_OPTS` allow
+* `GO_CONFIGURE_OPTS` and `GO_MAKE_OPTS` and `GO_MAKE_INSTALL_OPTS` allow
   you to specify configure and make options for buildling CPython. These variables
-  will be passed to Python only, not any dependent packages (e.g. libyaml).
+  will be passed to Golang only, not any dependent packages (e.g. libyaml).
 
-### Applying patches to Python before compiling
+### Applying patches to Golang before compiling
 
-Both `pyenv install` and `python-build` support the `--patch` (`-p`) flag that
-signals that a patch from stdin should be applied to Python, Jython or PyPy
-source code before the `./configure` and compilation steps.
+Both `goenv install` and `go-build` support the `--patch` (`-p`) flag that
+signals that a patch from stdin should be applied to Golang source code before
+the `./configure` and compilation steps.
 
 Example usage:
 
 ```sh
 # applying a single patch
-$ pyenv install --patch 2.7.10 < /path/to/python.patch
+$ goenv install --patch 2.7.10 < /path/to/golang.patch
 
 # applying a patch from HTTP
-$ pyenv install --patch 2.7.10 < <(curl -sSL http://git.io/python.patch)
+$ goenv install --patch 2.7.10 < <(curl -sSL http://git.io/golang.patch)
 
 # applying multiple patches
-$ cat fix1.patch fix2.patch | pyenv install --patch 2.7.10
+$ cat fix1.patch fix2.patch | goenv install --patch 2.7.10
 ```
 
 
@@ -152,18 +151,18 @@ $ cat fix1.patch fix2.patch | pyenv install --patch 2.7.10
 You can build CPython with `--enable-shared` to install a version with
 shared object.
 
-If `--enabled-shared` was found in `PYTHON_CONFIGURE_OPTS` or `CONFIGURE_OPTS`,
-`python-build` will automatically set `RPATH` to the pyenv's prefix directory.
+If `--enabled-shared` was found in `GO_CONFIGURE_OPTS` or `CONFIGURE_OPTS`,
+`go-build` will automatically set `RPATH` to the goenv's prefix directory.
 This means you don't have to set `LD_LIBRARY_PATH` or `DYLD_LIBRARY_PATH` for
 the version(s) installed with `--enable-shared`.
 
 ```sh
-$ env PYTHON_CONFIGURE_OPTS="--enable-shared` pyenv install 2.7.9
+$ env GO_CONFIGURE_OPTS="--enable-shared` goenv install 2.7.9
 ```
 
 ### Checksum verification
 
-If you have the `shasum`, `openssl`, or `sha256sum` tool installed, python-build will
+If you have the `shasum`, `openssl`, or `sha256sum` tool installed, go-build will
 automatically verify the SHA2 checksum of each downloaded package before
 installing it.
 
@@ -172,51 +171,51 @@ definition. (All bundled definitions include checksums.)
 
 ### Package download mirrors
 
-python-build will first attempt to download package files from a mirror hosted on
+go-build will first attempt to download package files from a mirror hosted on
 GitHub Pages. If a package is not available on the mirror, if the mirror
-is down, or if the download is corrupt, python-build will fall back to the
+is down, or if the download is corrupt, go-build will fall back to the
 official URL specified in the defintion file.
 
-You can point python-build to another mirror by specifying the
-`PYTHON_BUILD_MIRROR_URL` environment variable--useful if you'd like to run your
+You can point go-build to another mirror by specifying the
+`GO_BUILD_MIRROR_URL` environment variable--useful if you'd like to run your
 own local mirror, for example. Package mirror URLs are constructed by joining
 this variable with the SHA2 checksum of the package file.
 
-If you don't have an SHA2 program installed, python-build will skip the download
-mirror and use official URLs instead. You can force python-build to bypass the
-mirror by setting the `PYTHON_BUILD_SKIP_MIRROR` environment variable.
+If you don't have an SHA2 program installed, go-build will skip the download
+mirror and use official URLs instead. You can force go-build to bypass the
+mirror by setting the `GO_BUILD_SKIP_MIRROR` environment variable.
 
-The official python-build download mirror is provided by
-[GitHub Pages](http://yyuu.github.io/pythons/).
+The official go-build download mirror is provided by
+[GitHub Pages](http://syndbg.github.io/golangs/).
 
 ### Package download caching
 
-You can instruct python-build to keep a local cache of downloaded package files
-by setting the `PYTHON_BUILD_CACHE_PATH` environment variable. When set, package
+You can instruct go-build to keep a local cache of downloaded package files
+by setting the `GO_BUILD_CACHE_PATH` environment variable. When set, package
 files will be kept in this directory after the first successful download and
-reused by subsequent invocations of `python-build` and `pyenv install`.
+reused by subsequent invocations of `go-build` and `goenv install`.
 
-The `pyenv install` command defaults this path to `~/.pyenv/cache`, so in most
+The `goenv install` command defaults this path to `~/.goenv/cache`, so in most
 cases you can enable download caching simply by creating that directory.
 
 ### Keeping the build directory after installation
 
-Both `python-build` and `pyenv install` accept the `-k` or `--keep` flag, which
-tells python-build to keep the downloaded source after installation. This can be
-useful if you need to use `gdb` and `memprof` with Python.
+Both `go-build` and `goenv install` accept the `-k` or `--keep` flag, which
+tells go-build to keep the downloaded source after installation. This can be
+useful if you need to use `gdb` and `memprof` with Golang.
 
-Source code will be kept in a parallel directory tree `~/.pyenv/sources` when
-using `--keep` with the `pyenv install` command. You should specify the
-location of the source code with the `PYTHON_BUILD_BUILD_PATH` environment
-variable when using `--keep` with `python-build`.
+Source code will be kept in a parallel directory tree `~/.goenv/sources` when
+using `--keep` with the `goenv install` command. You should specify the
+location of the source code with the `GOLANG_BUILD_BUILD_PATH` environment
+variable when using `--keep` with `go-build`.
 
 
 ## Getting Help
 
-Please see the [pyenv wiki](https://github.com/yyuu/pyenv/wiki) for solutions to common problems.
+Please see the [goenv wiki](https://github.com/syndbg/goenv/wiki) for solutions to common problems.
 
-[wiki]: https://github.com/yyuu/pyenv/wiki
+[wiki]: https://github.com/syndbg/goenv/wiki
 
 If you can't find an answer on the wiki, open an issue on the [issue
-tracker](https://github.com/yyuu/pyenv/issues). Be sure to include
+tracker](https://github.com/syndbg/goenv/issues). Be sure to include
 the full build log for build failures.


### PR DESCRIPTION
This may not be totally correct - there are some references to CPython - but its slightly less confusing than the last version.