### PR TITLE
modified FreeBSD command

### DIFF
--- a/plugins/go-build/share/go-build/1.7.5
+++ b/plugins/go-build/share/go-build/1.7.5
@@ -1,8 +1,8 @@
 install_darwin_64bit "Go Darwin 64bit 1.7.5" "https://storage.googleapis.com/golang/go1.7.5.darwin-amd64.tar.gz#2e2a5e0a5c316cf922cf7d59ee5724d49fc35b07a154f6c4196172adfc14b2ca"
 
-install_freebsd_32bit "Go Freebsd 32bit 1.7.5" "https://storage.googleapis.com/golang/go1.7.5.freebsd-386.tar.gz#a47c56c7f5bd33e0a0877fbee0daa1eceb6885954796ef63ffa25a570d73aa78"
+install_bsd_32bit "Go Freebsd 32bit 1.7.5" "https://storage.googleapis.com/golang/go1.7.5.freebsd-386.tar.gz#a47c56c7f5bd33e0a0877fbee0daa1eceb6885954796ef63ffa25a570d73aa78"
 
-install_freebsd_64bit "Go Freebsd 64bit 1.7.5" "https://storage.googleapis.com/golang/go1.7.5.freebsd-amd64.tar.gz#c52e55a25d7925b5075de2266453d4ddf7b9245e26dbcaccb700129481ac9842"
+install_bsd_64bit "Go Freebsd 64bit 1.7.5" "https://storage.googleapis.com/golang/go1.7.5.freebsd-amd64.tar.gz#c52e55a25d7925b5075de2266453d4ddf7b9245e26dbcaccb700129481ac9842"
 
 install_linux_32bit "Go Linux 32bit 1.7.5" "https://storage.googleapis.com/golang/go1.7.5.linux-386.tar.gz#432cb92ae656f6fe1fa96a981782ef5948438b6da6691423aae900918b1eb955"
 


### PR DESCRIPTION
Because "install_freebsd_32bit" and "install_freebsd_64bit" is not working for Ubuntu 16.10, please change them to "install_bsd_32bit" and "install_bsd_64bit". These commands work for me well.