### PR TITLE
Add 1.8.1 to go-build recipes

### DIFF
--- a/plugins/go-build/share/go-build/1.8.1
+++ b/plugins/go-build/share/go-build/1.8.1
@@ -1,0 +1,9 @@
+install_darwin_64bit "Go Darwin 64bit 1.8.1" "https://storage.googleapis.com/golang/go1.8.1.darwin-amd64.tar.gz#25b026fe2f4de7c80b227f69588b06b93787f5b5f134fbf2d652926c08c04bcd"
+
+install_bsd_32bit "Go Freebsd 32bit 1.8.1" "https://storage.googleapis.com/golang/go1.8.1.freebsd-386.tar.gz#8f6dd6acd2076e21b4e154d3daa8243fcedbdfd63be7cb54a3dae8be66e46bd9"
+
+install_bsd_64bit "Go Freebsd 64bit 1.8.1" "https://storage.googleapis.com/golang/go1.8.1.freebsd-amd64.tar.gz#91065d4bb311bba74d7c1e3e6bab82fbba24c9da8aeca9e803caabcc66de1af7"
+
+install_linux_32bit "Go Linux 32bit 1.8.1" "https://storage.googleapis.com/golang/go1.8.1.linux-386.tar.gz#cb3f4527112075a8b045d708f793aeee2709d2f5ddd320973a1413db06fddb50"
+
+install_linux_64bit "Go Linux 64bit 1.8.1" "https://storage.googleapis.com/golang/go1.8.1.linux-amd64.tar.gz#a579ab19d5237e263254f1eac5352efcf1d70b9dacadb6d6bb12b0911ede8994"


### PR DESCRIPTION
I added the location of go 1.8.1 to go-build recipes :)
