### PR TITLE
Prefer 'set' command to 'setenv' function for fish shell

### DIFF
--- a/libexec/goenv-init
+++ b/libexec/goenv-init
@@ -86,9 +86,9 @@ mkdir -p "${GOENV_ROOT}/"{shims,versions}
 
 case "$shell" in
 fish )
-  echo "setenv PATH '${GOENV_ROOT}/shims' \$PATH"
-  echo "setenv GOENV_SHELL $shell"
-  echo "setenv GOROOT (goenv prefix)"
+  echo "set -gx PATH '${GOENV_ROOT}/shims' \$PATH"
+  echo "set -gx GOENV_SHELL $shell"
+  echo "set -gx GOROOT (goenv prefix)"
 ;;
 * )
   echo 'export PATH="'${GOENV_ROOT}'/shims:${PATH}"'

--- a/libexec/goenv-sh-shell
+++ b/libexec/goenv-sh-shell
@@ -55,7 +55,7 @@ if goenv-prefix "${versions[@]}" >/dev/null; then
   IFS="$OLDIFS"
   case "$shell" in
   fish )
-    echo "setenv GOENV_VERSION \"${version}\""
+    echo "set -gx GOENV_VERSION \"${version}\""
     ;;
   * )
     echo "export GOENV_VERSION=\"${version}\""

--- a/test/init.bats
+++ b/test/init.bats
@@ -73,7 +73,7 @@ OUT
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
   run goenv-init - fish
   assert_success
-  assert_line 0 "setenv PATH '${GOENV_ROOT}/shims' \$PATH"
+  assert_line 0 "set -gx PATH '${GOENV_ROOT}/shims' \$PATH"
 }
 
 @test "can add shims to PATH more than once" {
@@ -87,7 +87,7 @@ OUT
   export PATH="${GOENV_ROOT}/shims:$PATH"
   run goenv-init - fish
   assert_success
-  assert_line 0 "setenv PATH '${GOENV_ROOT}/shims' \$PATH"
+  assert_line 0 "set -gx PATH '${GOENV_ROOT}/shims' \$PATH"
 }
 
 @test "outputs sh-compatible syntax" {

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -48,5 +48,5 @@ SH
 @test "shell change version (fish)" {
   mkdir -p "${GOENV_ROOT}/versions/1.2.3"
   GOENV_SHELL=fish run goenv-sh-shell 1.2.3
-  assert_success 'setenv GOENV_VERSION "1.2.3"'
+  assert_success 'set -gx GOENV_VERSION "1.2.3"'
 }


### PR DESCRIPTION
The `setenv` function in fish shell has changed in fish-shell/fish-shell@75600b6.

This function in `libexec/nodenv-init` produces `setenv: Too many arguments` error.
We should use `set` command with `-gx` option.
