### PR TITLE
Remove GOROOT when system's go

### DIFF
--- a/libexec/goenv-exec
+++ b/libexec/goenv-exec
@@ -34,7 +34,9 @@ for script in "${scripts[@]}"; do
 done
 
 shift 1
-# Go needs a GOROOT
-export GOROOT="$(goenv-prefix)/"
+# Go needs a GOROOT without system's Go
+if [[ $GOENV_VERSION != "system" ]]; then
+  export GOROOT="$(goenv-prefix)/"
+fi
 export PATH="${GOENV_BIN_PATH}:${GOROOT}/bin:${PATH}"
 exec -a "$GOENV_COMMAND" "$GOENV_COMMAND_PATH" "$@"

--- a/libexec/goenv-init
+++ b/libexec/goenv-init
@@ -88,12 +88,10 @@ case "$shell" in
 fish )
   echo "set -gx PATH '${GOENV_ROOT}/shims' \$PATH"
   echo "set -gx GOENV_SHELL $shell"
-  echo "set -gx GOROOT (goenv prefix)"
 ;;
 * )
   echo 'export PATH="'${GOENV_ROOT}'/shims:${PATH}"'
   echo "export GOENV_SHELL=$shell"
-  echo 'export GOROOT="$(goenv prefix)"'
 ;;
 esac
 


### PR DESCRIPTION
This PR will solve https://github.com/syndbg/goenv/issues/26

The followings are the points of this PR, but I'm not sure whether it's perfectly correct.

Point1: If `$(goenv version) == system`, don't set `GOROOT` in `libexec/goenv-exec`. Because `GOROOT` of system's go depends on how users installed go in system.

Point2: It's not necessary to set `GOROOT` in the script of `goenv init -`
- In case of system's go, goenv shouldn't touch `GOROOT` by the same reason in Point1.
- In other case(using goenv's go), `GOROOT` will be set in [here](https://github.com/syndbg/goenv/compare/master...kosukemori:remove-goroot?expand=1#diff-1b9493738f8dcd19f48cf92919daf168R39). So it's not necessary in `goenv init -`