### PR TITLE
1.10rc2 1.8.7 1.9.4

### DIFF
--- a/plugins/go-build/share/go-build/1.10rc2
+++ b/plugins/go-build/share/go-build/1.10rc2
@@ -1,0 +1,9 @@
+install_darwin_64bit "Go Darwin 64bit 1.10rc2" "https://dl.google.com/go/go1.10rc2.darwin-amd64.tar.gz#0bb044de48f35a1c4845714ee049a9c0ffa1d89bd41aaaa1a034142b095c96d0"
+
+install_bsd_32bit "Go Freebsd 32bit 1.10rc2" "https://dl.google.com/go/go1.10rc2.freebsd-386.tar.gz#f80526d319b19d7cf85f1f3c8a14e6be9765f35b6c586bfdf942db500e5f46c2"
+
+install_bsd_64bit "Go Freebsd 64bit 1.10rc2" "https://dl.google.com/go/go1.10rc2.freebsd-amd64.tar.gz#5b9b02ca787e61aabd0441795b3b10c97bc969f853496124a65697f6a50118b6"
+
+install_linux_32bit "Go Linux 32bit 1.10rc2" "https://dl.google.com/go/go1.10rc2.linux-386.tar.gz#18832b97cdc2f21783ac60fc0136f25c19d39b7cc43459f5114dd62c0a212fe4"
+
+install_linux_64bit "Go Linux 64bit 1.10rc2" "https://dl.google.com/go/go1.10rc2.linux-amd64.tar.gz#6a6a4c0654bc603bcfee4d6ac34a479c260ac61b3edcc8d6773384eb0bda512e"

--- a/plugins/go-build/share/go-build/1.8.7
+++ b/plugins/go-build/share/go-build/1.8.7
@@ -1,0 +1,9 @@
+install_darwin_64bit "Go Darwin 64bit 1.8.7" "https://dl.google.com/go/go1.8.7.darwin-amd64.tar.gz#02bc6fb577538d0279e3e760c19ac3985e1a44ee87b8920b4c8bf986b4a5a5a7"
+
+install_bsd_32bit "Go Freebsd 32bit 1.8.7" "https://dl.google.com/go/go1.8.7.freebsd-386.tar.gz#f0f7176bcca829e10abc97ec2f543ad00924d15e5f8fefdfbe833fd8674b0954"
+
+install_bsd_64bit "Go Freebsd 64bit 1.8.7" "https://dl.google.com/go/go1.8.7.freebsd-amd64.tar.gz#602f3125335a4469e32b3eb316d854f8720a6719490d7728f4ca7c37d7f0d288"
+
+install_linux_32bit "Go Linux 32bit 1.8.7" "https://dl.google.com/go/go1.8.7.linux-386.tar.gz#3afab0048a44f66c4132f1fe26d3301fa4c51b47e7176c2d3f311c49d9aa74d6"
+
+install_linux_64bit "Go Linux 64bit 1.8.7" "https://dl.google.com/go/go1.8.7.linux-amd64.tar.gz#de32e8db3dc030e1448a6ca52d87a1e04ad31c6b212007616cfcc87beb0e4d60"

--- a/plugins/go-build/share/go-build/1.9.4
+++ b/plugins/go-build/share/go-build/1.9.4
@@ -1,0 +1,9 @@
+install_darwin_64bit "Go Darwin 64bit 1.9.4" "https://dl.google.com/go/go1.9.4.darwin-amd64.tar.gz#0e694bfa289453ecb056cc70456e42fa331408cfa6cc985a14edb01d8b4fec51"
+
+install_bsd_32bit "Go Freebsd 32bit 1.9.4" "https://dl.google.com/go/go1.9.4.freebsd-386.tar.gz#ca5874943d1fe5f9698594f65bb4d82f9e0f7ca3a09b1c306819df6f7349fd17"
+
+install_bsd_64bit "Go Freebsd 64bit 1.9.4" "https://dl.google.com/go/go1.9.4.freebsd-amd64.tar.gz#d91c3dc997358af47fc0070c09586b3e7aa47282a75169fa6b00d9ac3ca61d89"
+
+install_linux_32bit "Go Linux 32bit 1.9.4" "https://dl.google.com/go/go1.9.4.linux-386.tar.gz#d440aee90dad851630559bcee2b767b543ce7e54f45162908f3e12c3489888ab"
+
+install_linux_64bit "Go Linux 64bit 1.9.4" "https://dl.google.com/go/go1.9.4.linux-amd64.tar.gz#15b0937615809f87321a457bb1265f946f9f6e736c563d6c5e0bd2c22e44f779"


### PR DESCRIPTION
[security] Go 1.8.7, Go 1.9.4, and Go 1.10rc2 are released

https://groups.google.com/forum/#!msg/golang-nuts/Gbhh1NxAjMU/dfW69X50AgAJ


