### PR TITLE
Add go 1.10.2 and 1.9.6 versions.

### DIFF
--- a/plugins/go-build/share/go-build/1.10.2
+++ b/plugins/go-build/share/go-build/1.10.2
@@ -1,0 +1,9 @@
+install_darwin_64bit "Go Darwin 64bit 1.10.2" "https://dl.google.com/go/go1.10.2.darwin-amd64.tar.gz#360ad908840217ee1b2a0b4654666b9abb3a12c8593405ba88ab9bba6e64eeda"
+
+install_bsd_32bit "Go Freebsd 32bit 1.10.2" "https://dl.google.com/go/go1.10.2.freebsd-386.tar.gz#f272774839a95041cf8874171ef6a8c6692e8784544ca05abbb29c66643d24a9"
+
+install_bsd_64bit "Go Freebsd 64bit 1.10.2" "https://dl.google.com/go/go1.10.2.freebsd-amd64.tar.gz#6174ff4c2da7ebb064e7f2b28419d2cd5d3f7de34bec9e42d3716bdb190c9955"
+
+install_linux_32bit "Go Linux 32bit 1.10.2" "https://dl.google.com/go/go1.10.2.linux-386.tar.gz#ea4caddf76b86ed5d101a61bc9a273be5b24d81f0567270bb4d5beaaded9b567"
+
+install_linux_64bit "Go Linux 64bit 1.10.2" "https://dl.google.com/go/go1.10.2.linux-amd64.tar.gz#4b677d698c65370afa33757b6954ade60347aaca310ea92a63ed717d7cb0c2ff"

--- a/plugins/go-build/share/go-build/1.9.6
+++ b/plugins/go-build/share/go-build/1.9.6
@@ -1,0 +1,9 @@
+install_darwin_64bit "Go Darwin 64bit 1.9.6" "https://dl.google.com/go/go1.9.6.darwin-amd64.tar.gz#3de992c35021963af33029b7c0703bf25d1a3bb9236d117ebde09a9e12dfe715"
+
+install_bsd_32bit "Go Freebsd 32bit 1.9.6" "https://dl.google.com/go/go1.9.6.freebsd-386.tar.gz#e038805a0211dff4935b9ec325a888aa70ab6dc655a2252ae93d8fbd6eb23413"
+
+install_bsd_64bit "Go Freebsd 64bit 1.9.6" "https://dl.google.com/go/go1.9.6.freebsd-amd64.tar.gz#d557b31eec03addeede54d007240a3d66d1f439fbf3f0666203fc3ef2e2cfe59"
+
+install_linux_32bit "Go Linux 32bit 1.9.6" "https://dl.google.com/go/go1.9.6.linux-386.tar.gz#de65e35d7e540578e78a3c6917b9e9033b55617ef894a1de1a6a6da5a1b948dd"
+
+install_linux_64bit "Go Linux 64bit 1.9.6" "https://dl.google.com/go/go1.9.6.linux-amd64.tar.gz#d1eb07f99ac06906225ac2b296503f06cc257b472e7d7817b8f822fe3766ebfe"


### PR DESCRIPTION
See https://groups.google.com/forum/#!searchin/golang-announce/go$201.10.2%7Csort:date/golang-announce/qXEbop4t-Wg/tOHb-KE3BAAJ and https://golang.org/dl/#stable.

Is it possible to scrape https://golang.org/dl/#stable page to generate go version files automatically?