### PR TITLE
Adaptation for BSD on amd64 arch. & Fixed typo for BSD on 32 bit arch.

### DIFF
--- a/plugins/go-build/bin/go-build
+++ b/plugins/go-build/bin/go-build
@@ -271,7 +271,7 @@ install_bsd_32bit() {
     if [ "$(uname -s)" = "FreeBSD" ]; then
         local arch="$(uname -m)"
 
-        if [ $arch = "i386" ] || [ $arch = 'i686']; then
+        if [ $arch = "i386" ] || [ $arch = 'i686' ]; then
             install_package_using "tarball" 1 "$@"
         fi
     fi

--- a/plugins/go-build/bin/go-build
+++ b/plugins/go-build/bin/go-build
@@ -261,7 +261,7 @@ install_bsd_64bit() {
     if [ "$(uname -s)" = "FreeBSD" ]; then
         local arch="$(uname -m)"
 
-        if [ $arch = "x86_64" ]; then
+        if [ $arch = "x86_64" ] || [ $arch = 'amd64' ]; then
             install_package_using "tarball" 1 "$@"
         fi
     fi


### PR DESCRIPTION
In my machine `uname -m` returns `amd64` so I fixed logic for determining architecture in `plugins/go-build/bin/go-build` especially in BSD-related function. It may be suggested to add similar architecture determining code for other OS.

In addition I fixed trivial typo.