### PR TITLE
issue: #51

### DIFF
--- a/libexec/goenv
+++ b/libexec/goenv
@@ -116,8 +116,9 @@ case "$command" in
 -h | --help )
   exec goenv-help
   ;;
-shell )
-  if [ -z "${GOENV_SHELL}" ]; then
+
+* )
+  if [ "$command" = "shell" ] && [ -z "${GOENV_SHELL}" ]; then
     echo 'eval "$(goenv init -)" has not been executed'
     echo "please read the installation instructions in the README"
     echo "also read COMMANDS.md about the shell command"
@@ -131,18 +132,6 @@ shell )
     else
       exec "$command_path" "$@"
     fi
-  fi
-  ;;
-
-* )
-  command_path="$(command -v "goenv-$command" || true)"
-  [ -n "$command_path" ] || abort "no such command \`$command'"
-
-  shift 1
-  if [ "$1" = --help ]; then
-    exec goenv-help "$command"
-  else
-    exec "$command_path" "$@"
   fi
   ;;
 esac

--- a/libexec/goenv
+++ b/libexec/goenv
@@ -116,6 +116,24 @@ case "$command" in
 -h | --help )
   exec goenv-help
   ;;
+shell )
+  if [ -z "${GOENV_SHELL}" ]; then
+    echo 'eval "$(goenv init -)" has not been executed'
+    echo "please read the installation instructions in the README"
+    echo "also read COMMANDS.md about the shell command"
+  else
+    command_path="$(command -v "goenv-$command" || true)"
+    [ -n "$command_path" ] || abort "no such command \`$command'"
+
+    shift 1
+    if [ "$1" = --help ]; then
+      exec goenv-help "$command"
+    else
+      exec "$command_path" "$@"
+    fi
+  fi
+  ;;
+
 * )
   command_path="$(command -v "goenv-$command" || true)"
   [ -n "$command_path" ] || abort "no such command \`$command'"


### PR DESCRIPTION
* added check for non-eval'd shell if `goenv shell` was used

This is a bit hacky, just copy pasting code...I'm sure there are cleaner ways of doing it, but it does "address" the concern in issue #51 