### PR TITLE
Add go 1.10.6 and 1.11.3

### DIFF
--- a/plugins/go-build/share/go-build/1.10.6
+++ b/plugins/go-build/share/go-build/1.10.6
@@ -1,0 +1,11 @@
+install_darwin_64bit "Go Darwin 64bit 1.10.6" "https://dl.google.com/go/go1.10.6.darwin-amd64.tar.gz#419e7a775c39074ff967b4e66fa212eb4fd310b1f15675ce13977b57635dd3a8"
+
+install_bsd_32bit "Go Freebsd 32bit 1.10.6" "https://dl.google.com/go/go1.10.6.freebsd-386.tar.gz#d1f0aef497588865967256030cb676c6c62f6a4b53649814e753ae150fbaa960"
+
+install_bsd_64bit "Go Freebsd 64bit 1.10.6" "https://dl.google.com/go/go1.10.6.freebsd-amd64.tar.gz#194a1a39a96bb8d7ed8370dae7768db47109f628aea4f1588f677f66c384955a"
+
+install_linux_32bit "Go Linux 32bit 1.10.6" "https://dl.google.com/go/go1.10.6.linux-386.tar.gz#171fe6cbecb2845b875a35ac7ad758d4c0c5bd03f330fa35d340de85b9070e71"
+
+install_linux_64bit "Go Linux 64bit 1.10.6" "https://dl.google.com/go/go1.10.6.linux-amd64.tar.gz#acbdedf28b55b38d2db6f06209a25a869a36d31bdcf09fd2ec3d40e1279e0592"
+
+install_linux_arm "Go Linux arm 1.10.6" "https://dl.google.com/go/go1.10.6.linux-armv6l.tar.gz#4da252fc7e834b7ce35d349fb581aa84a08adece926a0b9a8e4216451ffcb11e"

--- a/plugins/go-build/share/go-build/1.11.3
+++ b/plugins/go-build/share/go-build/1.11.3
@@ -1,0 +1,11 @@
+install_darwin_64bit "Go Darwin 64bit 1.11.3" "https://dl.google.com/go/go1.11.3.darwin-amd64.tar.gz#3d164d44fcb06a4bbd69d19d8d91308d601f7d855a1037346389644803fdf148"
+
+install_bsd_32bit "Go Freebsd 32bit 1.11.3" "https://dl.google.com/go/go1.11.3.freebsd-386.tar.gz#2b4aacf3dc09c8b210fe3daf00f7c17c97d29503070200ba46e04f2d93790672"
+
+install_bsd_64bit "Go Freebsd 64bit 1.11.3" "https://dl.google.com/go/go1.11.3.freebsd-amd64.tar.gz#29b3fcc8d80ac1ea10cd82ca78d3dac4e7242333b882855ea7bc8e3a9d974116"
+
+install_linux_32bit "Go Linux 32bit 1.11.3" "https://dl.google.com/go/go1.11.3.linux-386.tar.gz#c3fadf7f8652c060e18b7907fb8e15b853955b25aa661dbd991f6d6bc581d7a9"
+
+install_linux_64bit "Go Linux 64bit 1.11.3" "https://dl.google.com/go/go1.11.3.linux-amd64.tar.gz#d20a4869ffb13cee0f7ee777bf18c7b9b67ef0375f93fac1298519e0c227a07f"
+
+install_linux_arm "Go Linux arm 1.11.3" "https://dl.google.com/go/go1.11.3.linux-armv6l.tar.gz#384933e6e97b74c5125011c8f0539362bbed5a015978a34e441d7333d8e519b9"


### PR DESCRIPTION
## What
Add Go versions `1.10.6` and `1.11.3`. The links where fetched from https://golang.org/dl/

## Why
These 2 versions were recently released as a security release ([link](https://groups.google.com/forum/#!msg/golang-announce/Kw31K8G7Fi0/z2olKn-QCAAJ)).