### PR TITLE
`go-build` fails if curl or wget does not exist, but no error message is displayed.

### DIFF
--- a/plugins/go-build/bin/go-build
+++ b/plugins/go-build/bin/go-build
@@ -133,13 +133,13 @@ build_failed() {
 
     if ! rmdir "${BUILD_PATH}" 2>/dev/null; then
       echo "Inspect or clean up the working tree at ${BUILD_PATH}"
+    fi
 
-      if file_is_not_empty "$LOG_PATH"; then
-        colorize 33 "Results logged to ${LOG_PATH}"
-        printf "\n\n"
-        echo "Last 10 log lines:"
-        tail -n 10 "$LOG_PATH"
-      fi
+    if file_is_not_empty "$LOG_PATH"; then
+      colorize 33 "Results logged to ${LOG_PATH}"
+      printf "\n\n"
+      echo "Last 10 log lines:"
+      tail -n 10 "$LOG_PATH"
     fi
   } >&3
   exit 1

--- a/plugins/go-build/bin/go-build
+++ b/plugins/go-build/bin/go-build
@@ -430,7 +430,7 @@ http() {
     "http_${method}_wget" "$url" "$file"
   else
     echo "error: please install 'curl' or 'wget' and try again" >&2
-    exit 1
+    return 1
   fi
 }
 


### PR DESCRIPTION
`go-build` fails if curl or wget does not exist, but no error message is displayed.

I fixed it.

## How to reproduce problems

```
# In host PC, run ubuntu (no curl, no wget)
docker run --rm -it ubuntu bash
```

```
# in container  no curl, no wget
root@b0da95c4ca42:/# apt-get update 2>&1 > /dev/null && apt-get install -y git ca-certificates 2>&1 > /dev/null
debconf: delaying package configuration, since apt-utils is not installed
root@b0da95c4ca42:/# which curl; echo $?
1
root@b0da95c4ca42:/# which wget; echo $?
1
root@b0da95c4ca42:/# git clone https://github.com/syndbg/goenv.git ~/.goenv
Cloning into '/root/.goenv'...
remote: Enumerating objects: 29, done.
remote: Counting objects: 100% (29/29), done.
remote: Compressing objects: 100% (21/21), done.
remote: Total 13864 (delta 10), reused 21 (delta 5), pack-reused 13835
Receiving objects: 100% (13864/13864), 2.50 MiB | 2.06 MiB/s, done.
Resolving deltas: 100% (9488/9488), done.
root@b0da95c4ca42:/# echo 'export GOENV_ROOT="$HOME/.goenv"' >> ~/.bashrc
root@b0da95c4ca42:/# echo 'export PATH="$GOENV_ROOT/bin:$PATH"' >> ~/.bashrc
root@b0da95c4ca42:/# echo 'eval "$(goenv init -)"' >> ~/.bashrc
root@b0da95c4ca42:/# echo 'export PATH="$GOROOT/bin:$PATH"' >> ~/.bashrc
root@b0da95c4ca42:/# echo 'export PATH="$GOPATH/bin:$PATH"' >> ~/.bashrc
root@b0da95c4ca42:/# exec $SHELL
root@b0da95c4ca42:/# goenv install 1.12.7
Downloading go1.12.7.linux-amd64.tar.gz...
-> https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz
root@b0da95c4ca42:/# echo $?
1
```

I don't know why I got an error.

## Fixed(using this branch)

```
root@52cf5fbd4964:/# apt-get update 2>&1 > /dev/null && apt-get install -y git ca-certificates 2>&1 > /dev/null
debconf: delaying package configuration, since apt-utils is not installed
root@52cf5fbd4964:/# which curl; echo $?
1
root@52cf5fbd4964:/# which wget; echo $?
1
root@52cf5fbd4964:/# git clone https://github.com/pocari/goenv.git -b show-no-download-tools-error ~/.goenv
Cloning into '/root/.goenv'...
remote: Enumerating objects: 41, done.
remote: Counting objects: 100% (41/41), done.
remote: Compressing objects: 100% (30/30), done.
remote: Total 13876 (delta 15), reused 30 (delta 8), pack-reused 13835
Receiving objects: 100% (13876/13876), 2.51 MiB | 2.01 MiB/s, done.
Resolving deltas: 100% (9493/9493), done.
root@52cf5fbd4964:/# echo 'export GOENV_ROOT="$HOME/.goenv"' >> ~/.bashrc
root@52cf5fbd4964:/# echo 'export PATH="$GOENV_ROOT/bin:$PATH"' >> ~/.bashrc
root@52cf5fbd4964:/# echo 'eval "$(goenv init -)"' >> ~/.bashrc
root@52cf5fbd4964:/# echo 'export PATH="$GOROOT/bin:$PATH"' >> ~/.bashrc
root@52cf5fbd4964:/# echo 'export PATH="$GOPATH/bin:$PATH"' >> ~/.bashrc
root@52cf5fbd4964:/# exec $SHELL
root@52cf5fbd4964:/# goenv install 1.12.7
Downloading go1.12.7.linux-amd64.tar.gz...
-> https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz
error: failed to download Go Linux 64bit 1.12.7.tar.gz

BUILD FAILED (Ubuntu 18.04 using go-build 2.0.0beta1)

Results logged to /tmp/go-build.20190825043952.3184.log

Last 10 log lines:
/tmp/go-build.20190825043952.3184 /
error: please install 'curl' or 'wget' and try again
```

