### PR TITLE
Add ZPlug installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,6 +81,18 @@ export PATH="$GOROOT/bin:$PATH"
 export PATH="$PATH:$GOPATH/bin"
 ```
    
+## via ZPlug plugin manager for Zsh
+
+Add the following line to your `.zshrc`:
+
+```zplug "RiverGlide/zsh-goenv", from:gitlab```
+Then install the plugin
+~~~ zsh
+  $ source ~/.zshrc
+  $ zplug install
+~~~
+The ZPlug plugin will install and initialise `goenv` and add `goenv` and `goenv-install` to your `PATH`
+   
 ## Homebrew on Mac OS X
 
 You can also install goenv using the [Homebrew](http://brew.sh)


### PR DESCRIPTION
This PR updates the documentation to include installation via ZPlug plugin.

The plugin at https://gitlab.com/RiverGlide/zsh-goenv.git is pretty straightforward.
It uses git submodules to checkout goenv, and the plugin file itself adds goenv and goenv-install to the path as well as calling eval $(goenv init -)