### PR TITLE
feat(go): add 1.15.1

### DIFF
--- a/plugins/go-build/share/go-build/1.15.1
+++ b/plugins/go-build/share/go-build/1.15.1
@@ -1,0 +1,11 @@
+install_darwin_64bit "Go Darwin 64bit 1.15.1" "https://golang.org/dl/go1.15.1.darwin-amd64.tar.gz#b33341df847b4a48da40d957437c87642d221dde28c6f810b1ce26b74be2f661"
+
+install_bsd_32bit "Go Freebsd 32bit 1.15.1" "https://golang.org/dl/go1.15.1.freebsd-386.tar.gz#042b5f2a9eabac75f9dbd0f385e11b418fdec5fbd15b920cba5e7055d196b32b"
+
+install_bsd_64bit "Go Freebsd 64bit 1.15.1" "https://golang.org/dl/go1.15.1.freebsd-amd64.tar.gz#8e8b6aa8be70c9d03d0fcaddf5cc8b48f869ed34d275abb2604093087b3481b5"
+
+install_linux_32bit "Go Linux 32bit 1.15.1" "https://golang.org/dl/go1.15.1.linux-386.tar.gz#7e0c8e9749be69c28d3333a81ce8386916ba1306b40476a43f7794dc309eaf4c"
+
+install_linux_64bit "Go Linux 64bit 1.15.1" "https://golang.org/dl/go1.15.1.linux-amd64.tar.gz#70ac0dbf60a8ee9236f337ed0daa7a4c3b98f6186d4497826f68e97c0c0413f6"
+
+install_linux_arm "Go Linux arm 1.15.1" "https://golang.org/dl/go1.15.1.linux-armv6l.tar.gz#62db2fac55309f4bc1f73577165dcb331a4c649e39bdbe04943579e0b2b0c06e"

--- a/plugins/go-build/test/goenv-install.bats
+++ b/plugins/go-build/test/goenv-install.bats
@@ -146,6 +146,7 @@ OUT
 1.15.0
 1.15beta1
 1.15rc2
+1.15.1
 OUT
 }
 
@@ -519,6 +520,7 @@ Available versions:
   1.15.0
   1.15beta1
   1.15rc2
+  1.15.1
 OUT
 }
 
@@ -649,6 +651,7 @@ Available versions:
   1.15.0
   1.15beta1
   1.15rc2
+  1.15.1
 OUT
 }
 


### PR DESCRIPTION
# Context

Add Go 1.15.1 (security update)

# Reference(s)

- CVE-2020-24553 - https://seclists.org/fulldisclosure/2020/Sep/5
- https://github.com/golang/go/issues?q=milestone%3AGo1.15.1+label%3ACherryPickApproved
- https://github.com/golang/go/issues/40928