### PR TITLE
Support darwin-arm64 arch on 1.16beta1

### DIFF
--- a/plugins/go-build/bin/go-build
+++ b/plugins/go-build/bin/go-build
@@ -181,6 +181,16 @@ install_darwin_64bit() {
     fi
 }
 
+install_darwin_arm() {
+    if [ "$(uname -s)" = "Darwin" ]; then
+        local arch="$(uname -m)"
+
+        if [ $arch = "arm64" ]; then
+            install_package_using "tarball" 1 "$@"
+        fi
+    fi
+}
+
 install_darwin_106_64bit() {
     if [ "$(uname -s)" = "Darwin" ]; then
         local arch="$(uname -m)"

--- a/plugins/go-build/share/go-build/1.16beta1
+++ b/plugins/go-build/share/go-build/1.16beta1
@@ -1,5 +1,7 @@
 install_darwin_64bit "Go Darwin 64bit 1.16beta1" "https://golang.org/dl/go1.16beta1.darwin-amd64.tar.gz#c3518be5a17c7df746e2596e2ea310cd56348e05454f2bfbb25c5e84708dc2e2"
 
+install_darwin_arm "Go Darwin arm 1.16beta1" "https://golang.org/dl/go1.16beta1.darwin-arm64.tar.gz#fd57f47987bb330fd9b438e7b4c8941b63c3807366602d99c1d99e0122ec62f1"
+
 install_bsd_32bit "Go Freebsd 32bit 1.16beta1" "https://golang.org/dl/go1.16beta1.freebsd-386.tar.gz#0331c620bb09a3c7f5022bf45f14c28ceb4b043e01ecadde68a1ceff4df50f24"
 
 install_bsd_64bit "Go Freebsd 64bit 1.16beta1" "https://golang.org/dl/go1.16beta1.freebsd-amd64.tar.gz#87e72b34ae706c2269e3e665906514d11aa75856da1c99c512206e7cb3a18b74"


### PR DESCRIPTION
It seems like that the official build now provides support for Apple Silicon since 1.16beta1.
https://golang.org/dl/#go1.16beta1