### PR TITLE
Add Linux arm 64bit

### DIFF
--- a/plugins/go-build/bin/go-build
+++ b/plugins/go-build/bin/go-build
@@ -268,6 +268,16 @@ install_linux_32bit() {
     fi
 }
 
+install_linux_arm_64bit() {
+    if [ "$(uname -s)" = "Linux" ]; then
+        local arch="$(uname -m)"
+
+        if [ $arch = "aarch64" ]; then
+            install_package_using "tarball" 1 "$@"
+        fi
+    fi
+}
+
 install_linux_arm() {
     if [ "$(uname -s)" = "Linux" ]; then
         local arch="$(uname -m)"

--- a/plugins/go-build/share/go-build/1.14.0
+++ b/plugins/go-build/share/go-build/1.14.0
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.0" "https://dl.google.com/go/go1.14.lin
 install_linux_64bit "Go Linux 64bit 1.14.0" "https://dl.google.com/go/go1.14.linux-amd64.tar.gz#08df79b46b0adf498ea9f320a0f23d6ec59e9003660b4c9c1ce8e5e2c6f823ca"
 
 install_linux_arm "Go Linux arm 1.14.0" "https://dl.google.com/go/go1.14.linux-armv6l.tar.gz#b5e682176d7ad3944404619a39b585453a740a2f82683e789f4279ec285b7ecd"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.0" "https://dl.google.com/go/go1.14.linux-arm64.tar.gz#cd813387f770c07819912f8ff4b9796a4e317dee92548b7226a19e60ac79eb27"

--- a/plugins/go-build/share/go-build/1.14.1
+++ b/plugins/go-build/share/go-build/1.14.1
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.1" "https://dl.google.com/go/go1.14.1.l
 install_linux_64bit "Go Linux 64bit 1.14.1" "https://dl.google.com/go/go1.14.1.linux-amd64.tar.gz#2f49eb17ce8b48c680cdb166ffd7389702c0dec6effa090c324804a5cac8a7f8"
 
 install_linux_arm "Go Linux arm 1.14.1" "https://dl.google.com/go/go1.14.1.linux-armv6l.tar.gz#04f10e345dae0d7c6c32ffd6356b47f2d4d0e8a0cb757f4ef48ead6c5bef206f"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.1" "https://dl.google.com/go/go1.14.1.linux-arm64.tar.gz#5d8f2c202f35481617e24e63cca30c6afb1ec2585006c4a6ecf16c5f4928ab3c"

--- a/plugins/go-build/share/go-build/1.14.10
+++ b/plugins/go-build/share/go-build/1.14.10
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.10" "https://golang.org/dl/go1.14.10.li
 install_linux_64bit "Go Linux 64bit 1.14.10" "https://golang.org/dl/go1.14.10.linux-amd64.tar.gz#66eb6858f375731ba07b0b33f5c813b141a81253e7e74071eec3ae85e9b37098"
 
 install_linux_arm "Go Linux arm 1.14.10" "https://golang.org/dl/go1.14.10.linux-armv6l.tar.gz#b601dbb186d786488470d73d4637c2144896bf6f499a4122bdd30f4e8dd79e70"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.10" "https://golang.org/dl/go1.14.10.linux-arm64.tar.gz#30700f7a9df3148df81013bd38715acd09ca5203b8e0aafa8b985306d5e9882e"

--- a/plugins/go-build/share/go-build/1.14.11
+++ b/plugins/go-build/share/go-build/1.14.11
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.11" "https://golang.org/dl/go1.14.11.li
 install_linux_64bit "Go Linux 64bit 1.14.11" "https://golang.org/dl/go1.14.11.linux-amd64.tar.gz#ef150041e1af0890ecdd98ebdd6c759096884052a584c09ce50b2b5bb9bab2cd"
 
 install_linux_arm "Go Linux arm 1.14.11" "https://golang.org/dl/go1.14.11.linux-armv6l.tar.gz#14ecce9dc6d9225d5686ff6c517c27d1d9189d7967b78a596d5f4325516fd093"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.11" "https://golang.org/dl/go1.14.11.linux-arm64.tar.gz#6a2dc3c8d41683cf5dbb695d58556ec187fea7ae1afd913e25fc0750ab9c162c"

--- a/plugins/go-build/share/go-build/1.14.12
+++ b/plugins/go-build/share/go-build/1.14.12
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.12" "https://golang.org/dl/go1.14.12.li
 install_linux_64bit "Go Linux 64bit 1.14.12" "https://golang.org/dl/go1.14.12.linux-amd64.tar.gz#fb26f951c88c0685d7df393611189c58e6eabd3c17bdaef37df11355ab8db9d3"
 
 install_linux_arm "Go Linux arm 1.14.12" "https://golang.org/dl/go1.14.12.linux-armv6l.tar.gz#548d0d93884d4c30684125a19ea169acf6195cf0fe467efb325adb595fffeacf"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.12" "https://golang.org/dl/go1.14.12.linux-arm64.tar.gz#833c762bf205ae5caaca246d5c2205ae919bad7484f7c38db72941937e28fa24"

--- a/plugins/go-build/share/go-build/1.14.13
+++ b/plugins/go-build/share/go-build/1.14.13
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.13" "https://golang.org/dl/go1.14.13.li
 install_linux_64bit "Go Linux 64bit 1.14.13" "https://golang.org/dl/go1.14.13.linux-amd64.tar.gz#bfea0c8d7b70c1ad99b0266b321608db57df75820e8f4333efa448a43da01992"
 
 install_linux_arm "Go Linux arm 1.14.13" "https://golang.org/dl/go1.14.13.linux-armv6l.tar.gz#cee8785fad978693c7b68ea635e76412a0a44917c3d58efa82b2edbf538a2868"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.13" "https://golang.org/dl/go1.14.13.linux-arm64.tar.gz#445b719ebf46d8825360dabad65226db154ca8053de60609bc20f80a17452cbb"

--- a/plugins/go-build/share/go-build/1.14.2
+++ b/plugins/go-build/share/go-build/1.14.2
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.2" "https://dl.google.com/go/go1.14.2.l
 install_linux_64bit "Go Linux 64bit 1.14.2" "https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz#6272d6e940ecb71ea5636ddb5fab3933e087c1356173c61f4a803895e947ebb3"
 
 install_linux_arm "Go Linux arm 1.14.2" "https://dl.google.com/go/go1.14.2.linux-armv6l.tar.gz#eb4550ba741506c2a4057ea4d3a5ad7ed5a887de67c7232f1e4795464361c83c"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.2" "https://dl.google.com/go/go1.14.2.linux-arm64.tar.gz#bb6d22fe5806352c3d0826676654e09b6e41eb1af52e8d506d3fa85adf7f8d88"

--- a/plugins/go-build/share/go-build/1.14.3
+++ b/plugins/go-build/share/go-build/1.14.3
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.3" "https://dl.google.com/go/go1.14.3.l
 install_linux_64bit "Go Linux 64bit 1.14.3" "https://dl.google.com/go/go1.14.3.linux-amd64.tar.gz#1c39eac4ae95781b066c144c58e45d6859652247f7515f0d2cba7be7d57d2226"
 
 install_linux_arm "Go Linux arm 1.14.3" "https://dl.google.com/go/go1.14.3.linux-armv6l.tar.gz#b1c3a648c3c8877b98dfba1996dec604c8fb8899db07994b2dfd47b0063367c8"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.3" "https://dl.google.com/go/go1.14.3.linux-arm64.tar.gz#a7a593e2ee079d83a1943edcd1c9ed2dae7529666fce04de8c142fb61c7cdd3e"

--- a/plugins/go-build/share/go-build/1.14.4
+++ b/plugins/go-build/share/go-build/1.14.4
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.4" "https://dl.google.com/go/go1.14.4.l
 install_linux_64bit "Go Linux 64bit 1.14.4" "https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz#aed845e4185a0b2a3c3d5e1d0a35491702c55889192bb9c30e67a3de6849c067"
 
 install_linux_arm "Go Linux arm 1.14.4" "https://dl.google.com/go/go1.14.4.linux-armv6l.tar.gz#e20211425b3f797ca6cd5e9a99ab6d5eaf1b009d08d19fc8a7835544fa58c703"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.4" "https://dl.google.com/go/go1.14.4.linux-arm64.tar.gz#05dc46ada4e23a1f58e72349f7c366aae2e9c7a7f1e7653095538bc5bba5e077"

--- a/plugins/go-build/share/go-build/1.14.5
+++ b/plugins/go-build/share/go-build/1.14.5
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.5" "https://golang.org/dl/go1.14.5.linu
 install_linux_64bit "Go Linux 64bit 1.14.5" "https://golang.org/dl/go1.14.5.linux-amd64.tar.gz#82a1b84f16858db03231eb201f90cce2a991078dda543879b87e738e2586854b"
 
 install_linux_arm "Go Linux arm 1.14.5" "https://golang.org/dl/go1.14.5.linux-armv6l.tar.gz#fc99d9cea2f2699d338f7e0ceb40d89c02019eec2b6500011a8743104274a46c"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.5" "https://golang.org/dl/go1.14.5.linux-arm64.tar.gz#27a3b3ca4fd60c8680cd2235d5ca38cad41ee8c41bd61891d39a8501ada5f677"

--- a/plugins/go-build/share/go-build/1.14.6
+++ b/plugins/go-build/share/go-build/1.14.6
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.6" "https://golang.org/dl/go1.14.6.linu
 install_linux_64bit "Go Linux 64bit 1.14.6" "https://golang.org/dl/go1.14.6.linux-amd64.tar.gz#5c566ddc2e0bcfc25c26a5dc44a440fcc0177f7350c1f01952b34d5989a0d287"
 
 install_linux_arm "Go Linux arm 1.14.6" "https://golang.org/dl/go1.14.6.linux-armv6l.tar.gz#cab39cc0fdf9731476a339af9d7bcd8fc661bfa323abb1ce9d1633fb31daeb07"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.6" "https://golang.org/dl/go1.14.6.linux-arm64.tar.gz#291bccfd7d7f1915599bbcc90e49d9fccfcb0004b7c62a2f5cdf0f96a09d6a3e"

--- a/plugins/go-build/share/go-build/1.14.7
+++ b/plugins/go-build/share/go-build/1.14.7
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.7" "https://golang.org/dl/go1.14.7.linu
 install_linux_64bit "Go Linux 64bit 1.14.7" "https://golang.org/dl/go1.14.7.linux-amd64.tar.gz#4a7fa60f323ee1416a4b1425aefc37ea359e9d64df19c326a58953a97ad41ea5"
 
 install_linux_arm "Go Linux arm 1.14.7" "https://golang.org/dl/go1.14.7.linux-armv6l.tar.gz#fe5b6f6e441f3cb7b53ebf1a010bbebcb720ac98124984cfe2e51d72b8a58c71"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.7" "https://golang.org/dl/go1.14.7.linux-arm64.tar.gz#fe5b6f6e441f3cb7b53ebf1a010bbebcb720ac98124984cfe2e51d72b8a58c71"

--- a/plugins/go-build/share/go-build/1.14.8
+++ b/plugins/go-build/share/go-build/1.14.8
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.8" "https://golang.org/dl/go1.14.8.linu
 install_linux_64bit "Go Linux 64bit 1.14.8" "https://golang.org/dl/go1.14.8.linux-amd64.tar.gz#5504e077a29d0bd6649ca7b66e317f1a4b264e960f74115d6f0f405c49a8e738"
 
 install_linux_arm "Go Linux arm 1.14.8" "https://golang.org/dl/go1.14.8.linux-armv6l.tar.gz#5d0c7a1cf79b044ad14414676c945a0e2ed61ae8167142d4e493118a66fafcb5"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.8" "https://golang.org/dl/go1.14.8.linux-arm64.tar.gz#52219e5508cbd8c93070d85f5ac8f1049eac5e89399666c46aa9edd9b1112725"

--- a/plugins/go-build/share/go-build/1.14.9
+++ b/plugins/go-build/share/go-build/1.14.9
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.14.9" "https://golang.org/dl/go1.14.9.linu
 install_linux_64bit "Go Linux 64bit 1.14.9" "https://golang.org/dl/go1.14.9.linux-amd64.tar.gz#f0d26ff572c72c9823ae752d3c81819a81a60c753201f51f89637482531c110a"
 
 install_linux_arm "Go Linux arm 1.14.9" "https://golang.org/dl/go1.14.9.linux-armv6l.tar.gz#e85dc09608dc9fc245ebc5daea0826898ac0eb0d48ed24e2300427850876c442"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.9" "https://golang.org/dl/go1.14.9.linux-arm64.tar.gz#65e6cef5c474a3514e754f6a7987c49388bb85a7b370370c1318087ac35427fa"

--- a/plugins/go-build/share/go-build/1.15.0
+++ b/plugins/go-build/share/go-build/1.15.0
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.15.0" "https://golang.org/dl/go1.15.linux-
 install_linux_64bit "Go Linux 64bit 1.15.0" "https://golang.org/dl/go1.15.linux-amd64.tar.gz#2d75848ac606061efe52a8068d0e647b35ce487a15bb52272c427df485193602"
 
 install_linux_arm "Go Linux arm 1.15.0" "https://golang.org/dl/go1.15.linux-armv6l.tar.gz#6d8914ddd25f85f2377c269ccfb359acf53adf71a42cdbf53434a7c76fa7a9bd"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.0" "https://golang.org/dl/go1.15.linux-arm64.tar.gz#7e18d92f61ddf480a4f9a57db09389ae7b9dadf68470d0cb9c00d734a0c57f8d"

--- a/plugins/go-build/share/go-build/1.15.1
+++ b/plugins/go-build/share/go-build/1.15.1
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.15.1" "https://golang.org/dl/go1.15.1.linu
 install_linux_64bit "Go Linux 64bit 1.15.1" "https://golang.org/dl/go1.15.1.linux-amd64.tar.gz#70ac0dbf60a8ee9236f337ed0daa7a4c3b98f6186d4497826f68e97c0c0413f6"
 
 install_linux_arm "Go Linux arm 1.15.1" "https://golang.org/dl/go1.15.1.linux-armv6l.tar.gz#62db2fac55309f4bc1f73577165dcb331a4c649e39bdbe04943579e0b2b0c06e"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.1" "https://golang.org/dl/go1.15.1.linux-arm64.tar.gz#ca21c771d906fbba8840b3a4831b1aa118f6e09b5d028323592faba382787a03"

--- a/plugins/go-build/share/go-build/1.15.2
+++ b/plugins/go-build/share/go-build/1.15.2
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.15.2" "https://golang.org/dl/go1.15.2.linu
 install_linux_64bit "Go Linux 64bit 1.15.2" "https://golang.org/dl/go1.15.2.linux-amd64.tar.gz#b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552"
 
 install_linux_arm "Go Linux arm 1.15.2" "https://golang.org/dl/go1.15.2.linux-armv6l.tar.gz#c12e2afdcb21e530d332d4994919f856dd2a676e9d67034c7d6fefcb241412d9"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.2" "https://golang.org/dl/go1.15.2.linux-arm64.tar.gz#c8ec460cc82d61604b048f9439c06bd591722efce5cd48f49e19b5f6226bd36d"

--- a/plugins/go-build/share/go-build/1.15.3
+++ b/plugins/go-build/share/go-build/1.15.3
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.15.3" "https://golang.org/dl/go1.15.3.linu
 install_linux_64bit "Go Linux 64bit 1.15.3" "https://golang.org/dl/go1.15.3.linux-amd64.tar.gz#010a88df924a81ec21b293b5da8f9b11c176d27c0ee3962dc1738d2352d3c02d"
 
 install_linux_arm "Go Linux arm 1.15.3" "https://golang.org/dl/go1.15.3.linux-armv6l.tar.gz#aacb49968d08e222c83dea7307b4523c3ae498a5d2e91cd0e480ef3f198ffef6"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.3" "https://golang.org/dl/go1.15.3.linux-arm64.tar.gz#b8b88a87ada918ef5189fa5938ef4c46a4f61952a34317612aaac705f4275f80"

--- a/plugins/go-build/share/go-build/1.15.4
+++ b/plugins/go-build/share/go-build/1.15.4
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.15.4" "https://golang.org/dl/go1.15.4.linu
 install_linux_64bit "Go Linux 64bit 1.15.4" "https://golang.org/dl/go1.15.4.linux-amd64.tar.gz#eb61005f0b932c93b424a3a4eaa67d72196c79129d9a3ea8578047683e2c80d5"
 
 install_linux_arm "Go Linux arm 1.15.4" "https://golang.org/dl/go1.15.4.linux-armv6l.tar.gz#fe449ad3e121472e5db2f70becc0fef9d1a7188616c0605ada63f1e3bbad280e"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.4" "https://golang.org/dl/go1.15.4.linux-arm64.tar.gz#6f083b453484fc5f95afb345547a58ccc957cde91348b7a7c68f5b060e488c85"

--- a/plugins/go-build/share/go-build/1.15.5
+++ b/plugins/go-build/share/go-build/1.15.5
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.15.5" "https://golang.org/dl/go1.15.5.linu
 install_linux_64bit "Go Linux 64bit 1.15.5" "https://golang.org/dl/go1.15.5.linux-amd64.tar.gz#9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d"
 
 install_linux_arm "Go Linux arm 1.15.5" "https://golang.org/dl/go1.15.5.linux-armv6l.tar.gz#5ea6456620d3efed5dda99238c7f23866eafdd915e5348736e631bc283c0238a"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.5" "https://golang.org/dl/go1.15.5.linux-arm64.tar.gz#a72a0b036beb4193a0214bca3fca4c5d68a38a4ccf098c909f7ce8bf08567c48"

--- a/plugins/go-build/share/go-build/1.15.6
+++ b/plugins/go-build/share/go-build/1.15.6
@@ -9,3 +9,5 @@ install_linux_32bit "Go Linux 32bit 1.15.6" "https://golang.org/dl/go1.15.6.linu
 install_linux_64bit "Go Linux 64bit 1.15.6" "https://golang.org/dl/go1.15.6.linux-amd64.tar.gz#3918e6cc85e7eaaa6f859f1bdbaac772e7a825b0eb423c63d3ae68b21f84b844"
 
 install_linux_arm "Go Linux arm 1.15.6" "https://golang.org/dl/go1.15.6.linux-armv6l.tar.gz#40ba9a57764e374195018ef37c38a5fbac9bbce908eab436370631a84bfc5788"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.6" "https://golang.org/dl/go1.15.6.linux-arm64.tar.gz#f87515b9744154ffe31182da9341d0a61eb0795551173d242c8cad209239e492"

--- a/plugins/go-build/share/go-build/1.16beta1
+++ b/plugins/go-build/share/go-build/1.16beta1
@@ -11,3 +11,5 @@ install_linux_32bit "Go Linux 32bit 1.16beta1" "https://golang.org/dl/go1.16beta
 install_linux_64bit "Go Linux 64bit 1.16beta1" "https://golang.org/dl/go1.16beta1.linux-amd64.tar.gz#3931a0d493d411d6c697df6f15d5292fdd8031fde7014fded399effdad4c12d8"
 
 install_linux_arm "Go Linux arm 1.16beta1" "https://golang.org/dl/go1.16beta1.linux-armv6l.tar.gz#2f31ed765b328f79d58f78a433f6e59295b77da63153fc7582f8d8402c344999"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.16beta1" "https://golang.org/dl/go1.16beta1.linux-arm64.tar.gz#b0f66bca136b4de8fd29645b50efa9941dc5b9eb5a67a3da837d5f8096b3431c"

--- a/plugins/go-build/test/fixtures/definitions/1.2.0
+++ b/plugins/go-build/test/fixtures/definitions/1.2.0
@@ -13,3 +13,5 @@ install_bsd_32bit "Go FreeBSD 32bit 1.2.0" "http://localhost:8090/1.2.0/1.2.0.ta
 install_linux_32bit "Go Linux 32bit 1.2.0" "http://localhost:8090/1.2.0/1.2.0.tar.gz#d7518d03fc9d7ac1d32c49358594ff6517712c3d3de4f80ebaa3229361f38937"
 
 install_linux_64bit "Go Linux 64bit 1.2.0" "http://localhost:8090/1.2.0/1.2.0.tar.gz#d7518d03fc9d7ac1d32c49358594ff6517712c3d3de4f80ebaa3229361f38937"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.2.0" "http://localhost:8090/1.2.0/1.2.0.tar.gz#d7518d03fc9d7ac1d32c49358594ff6517712c3d3de4f80ebaa3229361f38937"

--- a/plugins/go-build/test/fixtures/definitions/1.2.2
+++ b/plugins/go-build/test/fixtures/definitions/1.2.2
@@ -13,3 +13,5 @@ install_bsd_32bit "Go FreeBSD 32bit 1.2.2" "http://localhost:8090/1.2.2/1.2.2.ta
 install_linux_32bit "Go Linux 32bit 1.2.2" "http://localhost:8090/1.2.2/1.2.2.tar.gz#d7518d03fc9d7ac1d32c49358594ff6517712c3d3de4f80ebaa3229361f38937"
 
 install_linux_64bit "Go Linux 64bit 1.2.2" "http://localhost:8090/1.2.2/1.2.2.tar.gz#d7518d03fc9d7ac1d32c49358594ff6517712c3d3de4f80ebaa3229361f38937"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.2.2" "http://localhost:8090/1.2.2/1.2.2.tar.gz#d7518d03fc9d7ac1d32c49358594ff6517712c3d3de4f80ebaa3229361f38937"

--- a/plugins/go-build/test/goenv-install.bats
+++ b/plugins/go-build/test/goenv-install.bats
@@ -722,6 +722,11 @@ SH
 
   rm -rf $GOENV_ROOT
 
+  arch=" "
+  if [ "$(uname -m)" = "aarch64" ]; then
+    arch=" arm "
+  fi
+
   unameOut="$(uname -s)"
   case "${unameOut}" in
       Linux*)
@@ -729,8 +734,8 @@ SH
 before: ${GOENV_ROOT}/versions/1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
-Installing Go Linux 64bit 1.2.2...
-Installed Go Linux 64bit 1.2.2 to ${GOENV_ROOT}/versions/1.2.2
+Installing Go Linux${arch}64bit 1.2.2...
+Installed Go Linux${arch}64bit 1.2.2 to ${GOENV_ROOT}/versions/1.2.2
 
 after: 0
 REHASHED
@@ -777,6 +782,11 @@ SH
 
   rm -rf $GOENV_ROOT
 
+  arch=" "
+  if [ "$(uname -m)" = "aarch64" ]; then
+    arch=" arm "
+  fi
+
   unameOut="$(uname -s)"
   case "${unameOut}" in
       Linux*)
@@ -784,8 +794,8 @@ SH
 before: ${GOENV_ROOT}/versions/1.2.2
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
-Installing Go Linux 64bit 1.2.2...
-Installed Go Linux 64bit 1.2.2 to ${GOENV_ROOT}/versions/1.2.2
+Installing Go Linux${arch}64bit 1.2.2...
+Installed Go Linux${arch}64bit 1.2.2 to ${GOENV_ROOT}/versions/1.2.2
 
 after: 0
 REHASHED
@@ -819,14 +829,19 @@ OUT
 
   run goenv-install -f 1.2.2
 
+  arch=" "
+  if [ "$(uname -m)" = "aarch64" ]; then
+    arch=" arm "
+  fi
+
   unameOut="$(uname -s)"
   case "${unameOut}" in
       Linux*)
         assert_output <<-OUT
 Downloading 1.2.2.tar.gz...
 -> http://localhost:8090/1.2.2/1.2.2.tar.gz
-Installing Go Linux 64bit 1.2.2...
-Installed Go Linux 64bit 1.2.2 to ${GOENV_ROOT}/versions/1.2.2
+Installing Go Linux${arch}64bit 1.2.2...
+Installed Go Linux${arch}64bit 1.2.2 to ${GOENV_ROOT}/versions/1.2.2
 
 OUT
 ;;
@@ -888,6 +903,11 @@ OUT
 
   run goenv-install -f 1.2
 
+  arch=" "
+  if [ "$(uname -m)" = "aarch64" ]; then
+    arch=" arm "
+  fi
+
   unameOut="$(uname -s)"
   case "${unameOut}" in
       Linux*)
@@ -895,8 +915,8 @@ OUT
 Adding patch version 0 to 1.2
 Downloading 1.2.0.tar.gz...
 -> http://localhost:8090/1.2.0/1.2.0.tar.gz
-Installing Go Linux 64bit 1.2.0...
-Installed Go Linux 64bit 1.2.0 to ${GOENV_ROOT}/versions/1.2.0
+Installing Go Linux${arch}64bit 1.2.0...
+Installed Go Linux${arch}64bit 1.2.0 to ${GOENV_ROOT}/versions/1.2.0
 
 OUT
 ;;


### PR DESCRIPTION
I added current supported go versions, 1.14, 1.15, and 1.16beta1. 
I tested this branch by MacBook Air (M1, 2020) and [Parallels Technical Preview](https://www.parallels.com/blogs/parallels-desktop-apple-silicon-mac/).

<img width="684" alt="goenv screen shot" src="https://user-images.githubusercontent.com/1040576/104124540-c75da380-5394-11eb-9097-34a6e845a657.png">

Travis CI test is [passed](https://travis-ci.org/github/blp1526/goenv/builds/753786570).

---

At [additional commit](https://github.com/blp1526/goenv/commit/072cb9c8bc07d5b77b8ed1fe8f3b1df9ff642e0f), I tried to add `arch: arm64` to .travis.yml, but [test failed by timeout for some reasons](https://travis-ci.org/github/blp1526/goenv/builds/753788187).
Although, test succeeded at local machine.
I'm sorry that I don't know how to fix this Travis CI test problem.
But I think this PR is useful for some users, so I make this PR without updating `.travis.yml`.