### PR TITLE
ISSUE-169: GOENV_GOPATH_PREFIX does not work as expected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 # NOTE: Use `xenial` and/or newer since `make`
 # bundled there is new enough version to support `.ONESHELL` in `Makefile`.
 dist: xenial
-osx_image: xcode10.1
+osx_image: xcode12.2
 addons:
   homebrew:
     brewfile: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 # NOTE: Use `xenial` and/or newer since `make`
 # bundled there is new enough version to support `.ONESHELL` in `Makefile`.
 dist: xenial
+osx_image: xcode10.1
 addons:
   homebrew:
     brewfile: true

--- a/libexec/goenv-sh-rehash
+++ b/libexec/goenv-sh-rehash
@@ -66,11 +66,11 @@ if [ "${currentVersionName}" != "system" ]; then
         fi
       else
         if [ -n "${GOPATH}" ] && [ "${GOENV_APPEND_GOPATH}" = "1" ]; then
-          echo "export GOPATH=\"${GOENV_GOPATH_PREFIX}/${GOENV_VERSION}:${GOPATH}\""
+          echo "export GOPATH=\"${GOENV_GOPATH_PREFIX}/${currentVersionName}:${GOPATH}\""
         elif [ -n "${GOPATH}" ] && [ "${GOENV_PREPEND_GOPATH}" = "1" ]; then
-          echo "export GOPATH=\"${GOPATH}:${GOENV_GOPATH_PREFIX}/${GOENV_VERSION}\""
+          echo "export GOPATH=\"${GOPATH}:${GOENV_GOPATH_PREFIX}/${currentVersionName}\""
         else
-          echo "export GOPATH=\"${GOENV_GOPATH_PREFIX}/${GOENV_VERSION}\""
+          echo "export GOPATH=\"${GOENV_GOPATH_PREFIX}/${currentVersionName}\""
         fi
       fi
     fi


### PR DESCRIPTION
When rehash is executed and GOENV_DISABLE_GOPATH is 0 (default)
the code should use currentVersionName instead becasue GOENV_VERSION is
not set.