### PR TITLE
Add go1.16.3 (#173)

### DIFF
--- a/plugins/go-build/share/go-build/1.16.3
+++ b/plugins/go-build/share/go-build/1.16.3
@@ -1,0 +1,15 @@
+install_darwin_64bit "Go Darwin 64bit 1.16.3" "https://golang.org/dl/go1.16.3.darwin-amd64.tar.gz#6bb1cf421f8abc2a9a4e39140b7397cdae6aca3e8d36dcff39a1a77f4f1170ac"
+
+install_darwin_arm "Go Darwin arm 1.16.3" "https://golang.org/dl/go1.16.3.darwin-arm64.tar.gz#f4e96bbcd5d2d1942f5b55d9e4ab19564da4fad192012f6d7b0b9b055ba4208f"
+
+install_bsd_32bit "Go Freebsd 32bit 1.16.3" "https://golang.org/dl/go1.16.3.freebsd-386.tar.gz#31ecd11d497684fa8b0f01ba784590c4c760943665fdc4fe0adaa1405c71736c"
+
+install_bsd_64bit "Go Freebsd 64bit 1.16.3" "https://golang.org/dl/go1.16.3.freebsd-amd64.tar.gz#ffbd920b309e62e807457b11d80e8c17fefe3ef6de423aaba4b1e270b2ca4c3d"
+
+install_linux_32bit "Go Linux 32bit 1.16.3" "https://golang.org/dl/go1.16.3.linux-386.tar.gz#48b2d1481db756c88c18b1f064dbfc3e265ce4a775a23177ca17e25d13a24c5d"
+
+install_linux_64bit "Go Linux 64bit 1.16.3" "https://golang.org/dl/go1.16.3.linux-amd64.tar.gz#951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2"
+
+install_linux_arm "Go Linux arm 1.16.3" "https://golang.org/dl/go1.16.3.linux-armv6l.tar.gz#0dae30385e3564a557dac7f12a63eedc73543e6da0f6017990e214ce8cc8797c"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.16.3" "https://golang.org/dl/go1.16.3.linux-arm64.tar.gz#566b1d6f17d2bc4ad5f81486f0df44f3088c3ed47a3bec4099d8ed9939e90d5d"

--- a/plugins/go-build/test/goenv-install.bats
+++ b/plugins/go-build/test/goenv-install.bats
@@ -168,6 +168,7 @@ OUT
 1.16beta1
 1.16.1
 1.16.2
+1.16.3
 OUT
 }
 
@@ -563,6 +564,7 @@ Available versions:
   1.16beta1
   1.16.1
   1.16.2
+  1.16.3
 OUT
 }
 
@@ -715,6 +717,7 @@ Available versions:
   1.16beta1
   1.16.1
   1.16.2
+  1.16.3
 OUT
 }
 


### PR DESCRIPTION
Address #173 (Add go 1.16.3).

> go1.16.3 (released 2021/04/01) includes fixes to the compiler, linker, runtime, the go command, and the testing and time packages. See the Go 1.16.3 milestone on our issue tracker for details.

https://golang.org/doc/devel/release.html#go1.16