### PR TITLE
Use a POSIX-compatible regex in goenv-version-file-read

### DIFF
--- a/libexec/goenv-version-file-read
+++ b/libexec/goenv-version-file-read
@@ -13,7 +13,8 @@ fi
 # NOTE: Read the first non-whitespace word from the specified version file.
 # Be careful not to load it whole in case there's something crazy in it.
 IFS="${IFS}"$'\r'
-words=($(cut -b 1-1024 "$VERSION_FILE" | sed 's/^\s*\(\S\+\).*/\1/'))
+words=($(cut -b 1-1024 "$VERSION_FILE" | sed -n 's/^[[:space:]]*\([^[:space:]#][^[:space:]]*\).*/\1/p'))
+
 versions=("${words[@]}")
 
 if [ ! -n "$versions" ]; then


### PR DESCRIPTION
The use of POSIX regex makes goenv more portable -- namely, it allows goenv to
run on FreeBSD 13, where `regex(3)` is now strictly POSIX.
