### PR TITLE
Add 1.17rc1

### DIFF
--- a/plugins/go-build/share/go-build/1.17rc1
+++ b/plugins/go-build/share/go-build/1.17rc1
@@ -1,0 +1,15 @@
+install_darwin_64bit "Go Darwin 64bit 1.17rc1" "https://golang.org/dl/go1.17rc1.darwin-amd64.tar.gz#bc9971349a154e8c96e9488ea8f60f8d859725275a11562e38f4a7314df52200"
+
+install_darwin_arm "Go Darwin arm 1.17rc1" "https://golang.org/dl/go1.17rc1.darwin-arm64.tar.gz#39dcd3fe8443bfa42f17defaf5bc95944657e9a30f79c695d17e6738012110ff"
+
+install_bsd_32bit "Go Freebsd 32bit 1.17rc1" "https://golang.org/dl/go1.17rc1.freebsd-386.tar.gz#0e0ffff26c63f8cc9ffcf8ae9417c569e4c14b82b0e10abb6a3a422e5b191889"
+
+install_bsd_64bit "Go Freebsd 64bit 1.17rc1" "https://golang.org/dl/go1.17rc1.freebsd-amd64.tar.gz#d241d523f22744a244a19539d2c724130af6bed23e1ba034a4e8f0624af0f9b3"
+
+install_linux_32bit "Go Linux 32bit 1.17rc1" "https://golang.org/dl/go1.17rc1.linux-386.tar.gz#e9b78a4bd98165b86bb887643f58cc0464cc7ff7fae12516fc43114809c71e07"
+
+install_linux_64bit "Go Linux 64bit 1.17rc1" "https://golang.org/dl/go1.17rc1.linux-amd64.tar.gz#bfbd3881a01ca3826777b1c40f241acacd45b14730d373259cd673d74e15e534"
+
+install_linux_arm "Go Linux arm 1.17rc1" "https://golang.org/dl/go1.17rc1.linux-armv6l.tar.gz#1fd5c3733d6fab5ebcb3ca6ae2b478d370bb0638ba3966284ed7e7aa97acfc8a"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.17rc1" "https://golang.org/dl/go1.17rc1.linux-arm64.tar.gz#7498e426ce814a94a1d271d6bb80b9a2cf8c77ec49df531c57bd7a9ff82cfa4e"

--- a/plugins/go-build/test/goenv-install.bats
+++ b/plugins/go-build/test/goenv-install.bats
@@ -177,6 +177,7 @@ OUT
 1.16.5
 1.16.6
 1.17beta1
+1.17rc1
 OUT
 }
 
@@ -581,6 +582,7 @@ Available versions:
   1.16.5
   1.16.6
   1.17beta1
+  1.17rc1
 OUT
 }
 
@@ -742,6 +744,7 @@ Available versions:
   1.16.5
   1.16.6
   1.17beta1
+  1.17rc1
 OUT
 }
 


### PR DESCRIPTION
Go 1.17rc1 has also been released. Would you please support it? (Ref. #184)

<img width="591" alt="スクリーンショット 2021-07-14 9 21 53" src="https://user-images.githubusercontent.com/72645163/125542106-a01cbd08-fe54-4679-aefb-4753dcece1da.png">
