### PR TITLE
Show progress bar during download tarball

### DIFF
--- a/plugins/go-build/bin/go-build
+++ b/plugins/go-build/bin/go-build
@@ -462,10 +462,10 @@ http_head_curl() {
 }
 
 http_get_curl() {
-  options=""
+  options="--progress-bar"
   [ -n "${IPV4}" ] && options="--ipv4"
   [ -n "${IPV6}" ] && options="--ipv6"
-  curl -q -o "${2:--}" -sSLf ${options} "$1"
+  curl -q -o "${2:--}" -SLf ${options} "$1"
 }
 
 http_head_wget() {
@@ -476,10 +476,10 @@ http_head_wget() {
 }
 
 http_get_wget() {
-  options=""
+  options="--show-progress"
   [ -n "${IPV4}" ] && options="--inet4-only"
   [ -n "${IPV6}" ] && options="--inet6-only"
-  wget -nv ${options} -O "${2:--}" "$1"
+  wget -qnv ${options} -O "${2:--}" "$1"
 }
 
 fetch_tarball() {
@@ -564,7 +564,7 @@ download_tarball() {
 
   echo "-> $package_url" >&2
 
-  if http get "$package_url" "$package_filename" >&4 2>&1; then
+  if http get "$package_url" "$package_filename" >&4; then
     verify_checksum "$package_filename" "$checksum" >&4 2>&1 || return 1
   else
     echo "error: failed to download $package_filename" >&2


### PR DESCRIPTION
# Description

Address [Issue #172](https://github.com/syndbg/goenv/issues/172)

# Summary

- `curl`
  - Enable `--progress-bar` option.
  - Disable `-s (--silent)` option suppressing progress-bar.

- `wget`
  - Enable `--show-progress` option.
  - Enable `-q (--quiet)` option to suppress result message such as:
    `2021-07-26 02:04:05 URL:https://dl.google.com/go/go1.17rc1.darwin-amd64.tar.gz [135933957/135933957] -> "Go Darwin 64bit 1.17rc1.tar.gz" [1]`

- Both
  - Indicators write characters one by one.
  - Prompt needs to show them immediately without buffering by the redirect.

# Detail

- `curl`

  - Two indicators are shown. The first indicator is redirect response (code: 302).

  ```bash
  $ goenv install 1.17rc1
  Downloading go1.17rc1.darwin-amd64.tar.gz...
  -> https://golang.org/dl/go1.17rc1.darwin-amd64.tar.gz
  ########################################################################################## 100.0%
  ########################################################################################## 100.0%
  Installing Go Darwin 64bit 1.17rc1...
  Installed Go Darwin 64bit 1.17rc1 to /Users/umatare5/.goenv/versions/1.17rc1
  ```

- `wget`

  - Single indicator is shown.

  ```bash
  $ goenv install 1.17rc1
  Downloading go1.17rc1.darwin-amd64.tar.gz...
  -> https://golang.org/dl/go1.17rc1.darwin-amd64.tar.gz
  Go Darwin 64bit 1.17rc1.tar 100%[===================================>] 129.64M  73.4MB/s ETA 1.8s
  Installing Go Darwin 64bit 1.17rc1...
  Installed Go Darwin 64bit 1.17rc1 to /Users/umatare5/.goenv/versions/1.17rc1
  ```
