### PR TITLE
Migrate from `golang.org` to `go.dev`

### DIFF
--- a/plugins/go-build/bin/go-build
+++ b/plugins/go-build/bin/go-build
@@ -493,7 +493,7 @@ fetch_tarball() {
     package_url="${package_url%%#*}"
 
     if [ -n "$GO_BUILD_MIRROR_URL" ]; then
-      if [[ -z "$GO_BUILD_DEFAULT_MIRROR" || $package_url != */www.golang.org/* ]]; then
+      if [[ -z "$GO_BUILD_DEFAULT_MIRROR" || $package_url != */go.dev/* ]]; then
         mirror_url="${GO_BUILD_MIRROR_URL}/$checksum"
       fi
     fi

--- a/plugins/go-build/share/go-build/1.13.13
+++ b/plugins/go-build/share/go-build/1.13.13
@@ -1,11 +1,11 @@
-install_darwin_64bit "Go Darwin 64bit 1.13.13" "https://golang.org/dl/go1.13.13.darwin-amd64.tar.gz#9cb2c3b67daaf8cf3c3f4006e0f8d354c3d6ebe263349c277b3f714267b24288"
+install_darwin_64bit "Go Darwin 64bit 1.13.13" "https://go.dev/dl/go1.13.13.darwin-amd64.tar.gz#9cb2c3b67daaf8cf3c3f4006e0f8d354c3d6ebe263349c277b3f714267b24288"
 
-install_bsd_32bit "Go Freebsd 32bit 1.13.13" "https://golang.org/dl/go1.13.13.freebsd-386.tar.gz#ca39ea0304f5087254b0bc40a5cf6fbc2a267cb5c20a8bdec608e804439bc552"
+install_bsd_32bit "Go Freebsd 32bit 1.13.13" "https://go.dev/dl/go1.13.13.freebsd-386.tar.gz#ca39ea0304f5087254b0bc40a5cf6fbc2a267cb5c20a8bdec608e804439bc552"
 
-install_bsd_64bit "Go Freebsd 64bit 1.13.13" "https://golang.org/dl/go1.13.13.freebsd-amd64.tar.gz#db0cfac2a8c1f00808d801b83b7025f6715040d7d974ea4a0b9e98efa891677c"
+install_bsd_64bit "Go Freebsd 64bit 1.13.13" "https://go.dev/dl/go1.13.13.freebsd-amd64.tar.gz#db0cfac2a8c1f00808d801b83b7025f6715040d7d974ea4a0b9e98efa891677c"
 
-install_linux_32bit "Go Linux 32bit 1.13.13" "https://golang.org/dl/go1.13.13.linux-386.tar.gz#efcadf5d927558429ce1156e12943639e0f33d4b5b75919683ec2529ffb8c3e1"
+install_linux_32bit "Go Linux 32bit 1.13.13" "https://go.dev/dl/go1.13.13.linux-386.tar.gz#efcadf5d927558429ce1156e12943639e0f33d4b5b75919683ec2529ffb8c3e1"
 
-install_linux_64bit "Go Linux 64bit 1.13.13" "https://golang.org/dl/go1.13.13.linux-amd64.tar.gz#0b8573c2335bebef53e819ab8d323456dc2b94838bebdbd8cc6623bb8a6d77b7"
+install_linux_64bit "Go Linux 64bit 1.13.13" "https://go.dev/dl/go1.13.13.linux-amd64.tar.gz#0b8573c2335bebef53e819ab8d323456dc2b94838bebdbd8cc6623bb8a6d77b7"
 
-install_linux_arm "Go Linux arm 1.13.13" "https://golang.org/dl/go1.13.13.linux-armv6l.tar.gz#621081207d4d8549d33e2bc0623e50195152f40f3132327efecaa372f080af55"
+install_linux_arm "Go Linux arm 1.13.13" "https://go.dev/dl/go1.13.13.linux-armv6l.tar.gz#621081207d4d8549d33e2bc0623e50195152f40f3132327efecaa372f080af55"

--- a/plugins/go-build/share/go-build/1.13.14
+++ b/plugins/go-build/share/go-build/1.13.14
@@ -1,11 +1,11 @@
-install_darwin_64bit "Go Darwin 64bit 1.13.14" "https://golang.org/dl/go1.13.14.darwin-amd64.tar.gz#ea2a5d34d587e8d99925b365323eccb9895c4eec0264f1f81f989e98d5d041dd"
+install_darwin_64bit "Go Darwin 64bit 1.13.14" "https://go.dev/dl/go1.13.14.darwin-amd64.tar.gz#ea2a5d34d587e8d99925b365323eccb9895c4eec0264f1f81f989e98d5d041dd"
 
-install_bsd_32bit "Go Freebsd 32bit 1.13.14" "https://golang.org/dl/go1.13.14.freebsd-386.tar.gz#9b3eec9979e2446c1e6e1d905ca68de6742d6ff33d7a38ab8a14cc48d7d944ce"
+install_bsd_32bit "Go Freebsd 32bit 1.13.14" "https://go.dev/dl/go1.13.14.freebsd-386.tar.gz#9b3eec9979e2446c1e6e1d905ca68de6742d6ff33d7a38ab8a14cc48d7d944ce"
 
-install_bsd_64bit "Go Freebsd 64bit 1.13.14" "https://golang.org/dl/go1.13.14.freebsd-amd64.tar.gz#82385ecb116ffb5946a7469a942b82b2a084e296fbf384c1f99461dd39cda11b"
+install_bsd_64bit "Go Freebsd 64bit 1.13.14" "https://go.dev/dl/go1.13.14.freebsd-amd64.tar.gz#82385ecb116ffb5946a7469a942b82b2a084e296fbf384c1f99461dd39cda11b"
 
-install_linux_32bit "Go Linux 32bit 1.13.14" "https://golang.org/dl/go1.13.14.linux-386.tar.gz#537bb1769827852673ab96ce5f7676c162bba3d5394e6828733b53b4c9449c11"
+install_linux_32bit "Go Linux 32bit 1.13.14" "https://go.dev/dl/go1.13.14.linux-386.tar.gz#537bb1769827852673ab96ce5f7676c162bba3d5394e6828733b53b4c9449c11"
 
-install_linux_64bit "Go Linux 64bit 1.13.14" "https://golang.org/dl/go1.13.14.linux-amd64.tar.gz#32617db984b18308f2b00279c763bff060d2739229cb8037217a49c9e691b46a"
+install_linux_64bit "Go Linux 64bit 1.13.14" "https://go.dev/dl/go1.13.14.linux-amd64.tar.gz#32617db984b18308f2b00279c763bff060d2739229cb8037217a49c9e691b46a"
 
-install_linux_arm "Go Linux arm 1.13.14" "https://golang.org/dl/go1.13.14.linux-armv6l.tar.gz#1a238daa3cd00611145d66a5577ea57bf90266443d1a2bef076ca74302a02c48"
+install_linux_arm "Go Linux arm 1.13.14" "https://go.dev/dl/go1.13.14.linux-armv6l.tar.gz#1a238daa3cd00611145d66a5577ea57bf90266443d1a2bef076ca74302a02c48"

--- a/plugins/go-build/share/go-build/1.13.15
+++ b/plugins/go-build/share/go-build/1.13.15
@@ -1,11 +1,11 @@
-install_darwin_64bit "Go Darwin 64bit 1.13.15" "https://golang.org/dl/go1.13.15.darwin-amd64.tar.gz#63180e32e9b7bfcd0c1c056e7c215299f662a1098a30316599c7b3e2e2fa28e7"
+install_darwin_64bit "Go Darwin 64bit 1.13.15" "https://go.dev/dl/go1.13.15.darwin-amd64.tar.gz#63180e32e9b7bfcd0c1c056e7c215299f662a1098a30316599c7b3e2e2fa28e7"
 
-install_bsd_32bit "Go Freebsd 32bit 1.13.15" "https://golang.org/dl/go1.13.15.freebsd-386.tar.gz#335a4ce5eb8569afcc42aafb6b43677bd8a49f8861eac8c64e2ba0f0638c764f"
+install_bsd_32bit "Go Freebsd 32bit 1.13.15" "https://go.dev/dl/go1.13.15.freebsd-386.tar.gz#335a4ce5eb8569afcc42aafb6b43677bd8a49f8861eac8c64e2ba0f0638c764f"
 
-install_bsd_64bit "Go Freebsd 64bit 1.13.15" "https://golang.org/dl/go1.13.15.freebsd-amd64.tar.gz#021d3390a2b1b9cf172fce543265917f2cd724a6eba7be980ca65d8a2d9c81ff"
+install_bsd_64bit "Go Freebsd 64bit 1.13.15" "https://go.dev/dl/go1.13.15.freebsd-amd64.tar.gz#021d3390a2b1b9cf172fce543265917f2cd724a6eba7be980ca65d8a2d9c81ff"
 
-install_linux_32bit "Go Linux 32bit 1.13.15" "https://golang.org/dl/go1.13.15.linux-386.tar.gz#1a63e97b6f1a673966d6a4f4f7f9c724fdd68bdeac11425bf8a39c7a24ddc0a7"
+install_linux_32bit "Go Linux 32bit 1.13.15" "https://go.dev/dl/go1.13.15.linux-386.tar.gz#1a63e97b6f1a673966d6a4f4f7f9c724fdd68bdeac11425bf8a39c7a24ddc0a7"
 
-install_linux_64bit "Go Linux 64bit 1.13.15" "https://golang.org/dl/go1.13.15.linux-amd64.tar.gz#01cc3ddf6273900eba3e2bf311238828b7168b822bb57a9ccab4d7aa2acd6028"
+install_linux_64bit "Go Linux 64bit 1.13.15" "https://go.dev/dl/go1.13.15.linux-amd64.tar.gz#01cc3ddf6273900eba3e2bf311238828b7168b822bb57a9ccab4d7aa2acd6028"
 
-install_linux_arm "Go Linux arm 1.13.15" "https://golang.org/dl/go1.13.15.linux-armv6l.tar.gz#c58eacae1745769e77328aec08e0e3b4da1b4e99e1153046b1b00ae0b3338d42"
+install_linux_arm "Go Linux arm 1.13.15" "https://go.dev/dl/go1.13.15.linux-armv6l.tar.gz#c58eacae1745769e77328aec08e0e3b4da1b4e99e1153046b1b00ae0b3338d42"

--- a/plugins/go-build/share/go-build/1.14.10
+++ b/plugins/go-build/share/go-build/1.14.10
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.14.10" "https://golang.org/dl/go1.14.10.darwin-amd64.tar.gz#7d6b6a3b3c7b193f71a73bf3cecb3a234017db91056ecb605041c074d545dc61"
+install_darwin_64bit "Go Darwin 64bit 1.14.10" "https://go.dev/dl/go1.14.10.darwin-amd64.tar.gz#7d6b6a3b3c7b193f71a73bf3cecb3a234017db91056ecb605041c074d545dc61"
 
-install_bsd_32bit "Go Freebsd 32bit 1.14.10" "https://golang.org/dl/go1.14.10.freebsd-386.tar.gz#57c3bd2674f43d1d292b56ac0c684691b248caeba8c207943761ff10af346b96"
+install_bsd_32bit "Go Freebsd 32bit 1.14.10" "https://go.dev/dl/go1.14.10.freebsd-386.tar.gz#57c3bd2674f43d1d292b56ac0c684691b248caeba8c207943761ff10af346b96"
 
-install_bsd_64bit "Go Freebsd 64bit 1.14.10" "https://golang.org/dl/go1.14.10.freebsd-amd64.tar.gz#1c05493ac5886bc18edf17cb54a3be7627792c813fa6a2e132036b5911c9f3d7"
+install_bsd_64bit "Go Freebsd 64bit 1.14.10" "https://go.dev/dl/go1.14.10.freebsd-amd64.tar.gz#1c05493ac5886bc18edf17cb54a3be7627792c813fa6a2e132036b5911c9f3d7"
 
-install_linux_32bit "Go Linux 32bit 1.14.10" "https://golang.org/dl/go1.14.10.linux-386.tar.gz#0e8e955cc80d2d7046312d16d800be82aa8ce9c5165b936348851923a75b4484"
+install_linux_32bit "Go Linux 32bit 1.14.10" "https://go.dev/dl/go1.14.10.linux-386.tar.gz#0e8e955cc80d2d7046312d16d800be82aa8ce9c5165b936348851923a75b4484"
 
-install_linux_64bit "Go Linux 64bit 1.14.10" "https://golang.org/dl/go1.14.10.linux-amd64.tar.gz#66eb6858f375731ba07b0b33f5c813b141a81253e7e74071eec3ae85e9b37098"
+install_linux_64bit "Go Linux 64bit 1.14.10" "https://go.dev/dl/go1.14.10.linux-amd64.tar.gz#66eb6858f375731ba07b0b33f5c813b141a81253e7e74071eec3ae85e9b37098"
 
-install_linux_arm "Go Linux arm 1.14.10" "https://golang.org/dl/go1.14.10.linux-armv6l.tar.gz#b601dbb186d786488470d73d4637c2144896bf6f499a4122bdd30f4e8dd79e70"
+install_linux_arm "Go Linux arm 1.14.10" "https://go.dev/dl/go1.14.10.linux-armv6l.tar.gz#b601dbb186d786488470d73d4637c2144896bf6f499a4122bdd30f4e8dd79e70"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.14.10" "https://golang.org/dl/go1.14.10.linux-arm64.tar.gz#30700f7a9df3148df81013bd38715acd09ca5203b8e0aafa8b985306d5e9882e"
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.10" "https://go.dev/dl/go1.14.10.linux-arm64.tar.gz#30700f7a9df3148df81013bd38715acd09ca5203b8e0aafa8b985306d5e9882e"

--- a/plugins/go-build/share/go-build/1.14.11
+++ b/plugins/go-build/share/go-build/1.14.11
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.14.11" "https://golang.org/dl/go1.14.11.darwin-amd64.tar.gz#bf50244fbafb16bf599e73a07e6f407cde5508527ef39c25007b46e18e89ff27"
+install_darwin_64bit "Go Darwin 64bit 1.14.11" "https://go.dev/dl/go1.14.11.darwin-amd64.tar.gz#bf50244fbafb16bf599e73a07e6f407cde5508527ef39c25007b46e18e89ff27"
 
-install_bsd_32bit "Go Freebsd 32bit 1.14.11" "https://golang.org/dl/go1.14.11.freebsd-386.tar.gz#ac6d49919bf0f7ae42cfd3a40be203f645d39352bab2fac6168565da26fd3a71"
+install_bsd_32bit "Go Freebsd 32bit 1.14.11" "https://go.dev/dl/go1.14.11.freebsd-386.tar.gz#ac6d49919bf0f7ae42cfd3a40be203f645d39352bab2fac6168565da26fd3a71"
 
-install_bsd_64bit "Go Freebsd 64bit 1.14.11" "https://golang.org/dl/go1.14.11.freebsd-amd64.tar.gz#7ac69f2a667d0ec5c2ef9cabfb003cb1d2aea99011fdea3190fbfb55df092395"
+install_bsd_64bit "Go Freebsd 64bit 1.14.11" "https://go.dev/dl/go1.14.11.freebsd-amd64.tar.gz#7ac69f2a667d0ec5c2ef9cabfb003cb1d2aea99011fdea3190fbfb55df092395"
 
-install_linux_32bit "Go Linux 32bit 1.14.11" "https://golang.org/dl/go1.14.11.linux-386.tar.gz#3789de3f29cccb31004885f72065e947a5020cdc33ecd94db0b5f20d319c49f0"
+install_linux_32bit "Go Linux 32bit 1.14.11" "https://go.dev/dl/go1.14.11.linux-386.tar.gz#3789de3f29cccb31004885f72065e947a5020cdc33ecd94db0b5f20d319c49f0"
 
-install_linux_64bit "Go Linux 64bit 1.14.11" "https://golang.org/dl/go1.14.11.linux-amd64.tar.gz#ef150041e1af0890ecdd98ebdd6c759096884052a584c09ce50b2b5bb9bab2cd"
+install_linux_64bit "Go Linux 64bit 1.14.11" "https://go.dev/dl/go1.14.11.linux-amd64.tar.gz#ef150041e1af0890ecdd98ebdd6c759096884052a584c09ce50b2b5bb9bab2cd"
 
-install_linux_arm "Go Linux arm 1.14.11" "https://golang.org/dl/go1.14.11.linux-armv6l.tar.gz#14ecce9dc6d9225d5686ff6c517c27d1d9189d7967b78a596d5f4325516fd093"
+install_linux_arm "Go Linux arm 1.14.11" "https://go.dev/dl/go1.14.11.linux-armv6l.tar.gz#14ecce9dc6d9225d5686ff6c517c27d1d9189d7967b78a596d5f4325516fd093"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.14.11" "https://golang.org/dl/go1.14.11.linux-arm64.tar.gz#6a2dc3c8d41683cf5dbb695d58556ec187fea7ae1afd913e25fc0750ab9c162c"
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.11" "https://go.dev/dl/go1.14.11.linux-arm64.tar.gz#6a2dc3c8d41683cf5dbb695d58556ec187fea7ae1afd913e25fc0750ab9c162c"

--- a/plugins/go-build/share/go-build/1.14.12
+++ b/plugins/go-build/share/go-build/1.14.12
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.14.12" "https://golang.org/dl/go1.14.12.darwin-amd64.tar.gz#94dead73e89697612461fc657bea7a2da31f669e540aab09436691ec4a53e8b4"
+install_darwin_64bit "Go Darwin 64bit 1.14.12" "https://go.dev/dl/go1.14.12.darwin-amd64.tar.gz#94dead73e89697612461fc657bea7a2da31f669e540aab09436691ec4a53e8b4"
 
-install_bsd_32bit "Go Freebsd 32bit 1.14.12" "https://golang.org/dl/go1.14.12.freebsd-386.tar.gz#18873c97481cc9d38cfd44c8fada54908dbc5844dd53ab03635bb8bfb73569ec"
+install_bsd_32bit "Go Freebsd 32bit 1.14.12" "https://go.dev/dl/go1.14.12.freebsd-386.tar.gz#18873c97481cc9d38cfd44c8fada54908dbc5844dd53ab03635bb8bfb73569ec"
 
-install_bsd_64bit "Go Freebsd 64bit 1.14.12" "https://golang.org/dl/go1.14.12.freebsd-amd64.tar.gz#7fbfc2a4018f6dbbe4f202b0c669f19bf625d075d466cb48f0fc582b8155228d"
+install_bsd_64bit "Go Freebsd 64bit 1.14.12" "https://go.dev/dl/go1.14.12.freebsd-amd64.tar.gz#7fbfc2a4018f6dbbe4f202b0c669f19bf625d075d466cb48f0fc582b8155228d"
 
-install_linux_32bit "Go Linux 32bit 1.14.12" "https://golang.org/dl/go1.14.12.linux-386.tar.gz#80d1aa5c2a22cf57da97c71bbb3ee96f2600f15212f0fe8d6e07c7fc2744cf82"
+install_linux_32bit "Go Linux 32bit 1.14.12" "https://go.dev/dl/go1.14.12.linux-386.tar.gz#80d1aa5c2a22cf57da97c71bbb3ee96f2600f15212f0fe8d6e07c7fc2744cf82"
 
-install_linux_64bit "Go Linux 64bit 1.14.12" "https://golang.org/dl/go1.14.12.linux-amd64.tar.gz#fb26f951c88c0685d7df393611189c58e6eabd3c17bdaef37df11355ab8db9d3"
+install_linux_64bit "Go Linux 64bit 1.14.12" "https://go.dev/dl/go1.14.12.linux-amd64.tar.gz#fb26f951c88c0685d7df393611189c58e6eabd3c17bdaef37df11355ab8db9d3"
 
-install_linux_arm "Go Linux arm 1.14.12" "https://golang.org/dl/go1.14.12.linux-armv6l.tar.gz#548d0d93884d4c30684125a19ea169acf6195cf0fe467efb325adb595fffeacf"
+install_linux_arm "Go Linux arm 1.14.12" "https://go.dev/dl/go1.14.12.linux-armv6l.tar.gz#548d0d93884d4c30684125a19ea169acf6195cf0fe467efb325adb595fffeacf"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.14.12" "https://golang.org/dl/go1.14.12.linux-arm64.tar.gz#833c762bf205ae5caaca246d5c2205ae919bad7484f7c38db72941937e28fa24"
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.12" "https://go.dev/dl/go1.14.12.linux-arm64.tar.gz#833c762bf205ae5caaca246d5c2205ae919bad7484f7c38db72941937e28fa24"

--- a/plugins/go-build/share/go-build/1.14.13
+++ b/plugins/go-build/share/go-build/1.14.13
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.14.13" "https://golang.org/dl/go1.14.13.darwin-amd64.tar.gz#80f0b481239316b7f1f396fe30eb0495b87afc164661b1b82ef8e2aee1881988"
+install_darwin_64bit "Go Darwin 64bit 1.14.13" "https://go.dev/dl/go1.14.13.darwin-amd64.tar.gz#80f0b481239316b7f1f396fe30eb0495b87afc164661b1b82ef8e2aee1881988"
 
-install_bsd_32bit "Go Freebsd 32bit 1.14.13" "https://golang.org/dl/go1.14.13.freebsd-386.tar.gz#3dad62f0c70e5503de8b61c4adfd80ce286941d29bbf8ed63de795ba2b0c2223"
+install_bsd_32bit "Go Freebsd 32bit 1.14.13" "https://go.dev/dl/go1.14.13.freebsd-386.tar.gz#3dad62f0c70e5503de8b61c4adfd80ce286941d29bbf8ed63de795ba2b0c2223"
 
-install_bsd_64bit "Go Freebsd 64bit 1.14.13" "https://golang.org/dl/go1.14.13.freebsd-amd64.tar.gz#668b0408f00ca2cbcf7b19262670ac961bff606dc968c75207560f515a7fdb62"
+install_bsd_64bit "Go Freebsd 64bit 1.14.13" "https://go.dev/dl/go1.14.13.freebsd-amd64.tar.gz#668b0408f00ca2cbcf7b19262670ac961bff606dc968c75207560f515a7fdb62"
 
-install_linux_32bit "Go Linux 32bit 1.14.13" "https://golang.org/dl/go1.14.13.linux-386.tar.gz#a168c7e03e305d33a5651acb5bfdbfb5141053a0d98f06af3e1e5081167af963"
+install_linux_32bit "Go Linux 32bit 1.14.13" "https://go.dev/dl/go1.14.13.linux-386.tar.gz#a168c7e03e305d33a5651acb5bfdbfb5141053a0d98f06af3e1e5081167af963"
 
-install_linux_64bit "Go Linux 64bit 1.14.13" "https://golang.org/dl/go1.14.13.linux-amd64.tar.gz#bfea0c8d7b70c1ad99b0266b321608db57df75820e8f4333efa448a43da01992"
+install_linux_64bit "Go Linux 64bit 1.14.13" "https://go.dev/dl/go1.14.13.linux-amd64.tar.gz#bfea0c8d7b70c1ad99b0266b321608db57df75820e8f4333efa448a43da01992"
 
-install_linux_arm "Go Linux arm 1.14.13" "https://golang.org/dl/go1.14.13.linux-armv6l.tar.gz#cee8785fad978693c7b68ea635e76412a0a44917c3d58efa82b2edbf538a2868"
+install_linux_arm "Go Linux arm 1.14.13" "https://go.dev/dl/go1.14.13.linux-armv6l.tar.gz#cee8785fad978693c7b68ea635e76412a0a44917c3d58efa82b2edbf538a2868"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.14.13" "https://golang.org/dl/go1.14.13.linux-arm64.tar.gz#445b719ebf46d8825360dabad65226db154ca8053de60609bc20f80a17452cbb"
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.13" "https://go.dev/dl/go1.14.13.linux-arm64.tar.gz#445b719ebf46d8825360dabad65226db154ca8053de60609bc20f80a17452cbb"

--- a/plugins/go-build/share/go-build/1.14.14
+++ b/plugins/go-build/share/go-build/1.14.14
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.14.14" "https://golang.org/dl/go1.14.14.darwin-amd64.tar.gz#50a64d6a7ef85510321f0cbcd64e7c72f7e82e27c22f0ba475b9b6b6213f136e"
+install_darwin_64bit "Go Darwin 64bit 1.14.14" "https://go.dev/dl/go1.14.14.darwin-amd64.tar.gz#50a64d6a7ef85510321f0cbcd64e7c72f7e82e27c22f0ba475b9b6b6213f136e"
 
-install_bsd_32bit "Go Freebsd 32bit 1.14.14" "https://golang.org/dl/go1.14.14.freebsd-386.tar.gz#7865dffe01499e5e26a40ebc15e068e683e64a2f2edff7440fc9802b02f122bb"
+install_bsd_32bit "Go Freebsd 32bit 1.14.14" "https://go.dev/dl/go1.14.14.freebsd-386.tar.gz#7865dffe01499e5e26a40ebc15e068e683e64a2f2edff7440fc9802b02f122bb"
 
-install_bsd_64bit "Go Freebsd 64bit 1.14.14" "https://golang.org/dl/go1.14.14.freebsd-amd64.tar.gz#a4fab9549523eefe4cdb4d1334144cb51825db2cfe7993497773f5c9349f6647"
+install_bsd_64bit "Go Freebsd 64bit 1.14.14" "https://go.dev/dl/go1.14.14.freebsd-amd64.tar.gz#a4fab9549523eefe4cdb4d1334144cb51825db2cfe7993497773f5c9349f6647"
 
-install_linux_32bit "Go Linux 32bit 1.14.14" "https://golang.org/dl/go1.14.14.linux-386.tar.gz#b08e088ba99134035782c71aeaf139f36d2306eb88eddc22c1278b8b446f157e"
+install_linux_32bit "Go Linux 32bit 1.14.14" "https://go.dev/dl/go1.14.14.linux-386.tar.gz#b08e088ba99134035782c71aeaf139f36d2306eb88eddc22c1278b8b446f157e"
 
-install_linux_64bit "Go Linux 64bit 1.14.14" "https://golang.org/dl/go1.14.14.linux-amd64.tar.gz#6f1354c9040d65d1622b451f43c324c1e5197aa9242d00c5a117d0e2625f3e0d"
+install_linux_64bit "Go Linux 64bit 1.14.14" "https://go.dev/dl/go1.14.14.linux-amd64.tar.gz#6f1354c9040d65d1622b451f43c324c1e5197aa9242d00c5a117d0e2625f3e0d"
 
-install_linux_arm "Go Linux arm 1.14.14" "https://golang.org/dl/go1.14.14.linux-armv6l.tar.gz#e4d614c23b77a367becaeac3032cf4911793363a33efa299d29440be3d66234b"
+install_linux_arm "Go Linux arm 1.14.14" "https://go.dev/dl/go1.14.14.linux-armv6l.tar.gz#e4d614c23b77a367becaeac3032cf4911793363a33efa299d29440be3d66234b"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.14.14" "https://golang.org/dl/go1.14.14.linux-arm64.tar.gz#511d764197121f212d130724afb9c296f0cb4a22424e5ae956a5cc043b0f4a29"
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.14" "https://go.dev/dl/go1.14.14.linux-arm64.tar.gz#511d764197121f212d130724afb9c296f0cb4a22424e5ae956a5cc043b0f4a29"

--- a/plugins/go-build/share/go-build/1.14.15
+++ b/plugins/go-build/share/go-build/1.14.15
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.14.15" "https://golang.org/dl/go1.14.15.darwin-amd64.tar.gz#cc116e7522d1d1bcb606ce413555c4f2d5c86c0c8d5e5074a0d57b303d8edb50"
+install_darwin_64bit "Go Darwin 64bit 1.14.15" "https://go.dev/dl/go1.14.15.darwin-amd64.tar.gz#cc116e7522d1d1bcb606ce413555c4f2d5c86c0c8d5e5074a0d57b303d8edb50"
 
-install_bsd_32bit "Go Freebsd 32bit 1.14.15" "https://golang.org/dl/go1.14.15.freebsd-386.tar.gz#4d8eb68aa9bdc1d13cebe8884c6bf4f9cc0b8baea383620113ff6a2ac17c8d63"
+install_bsd_32bit "Go Freebsd 32bit 1.14.15" "https://go.dev/dl/go1.14.15.freebsd-386.tar.gz#4d8eb68aa9bdc1d13cebe8884c6bf4f9cc0b8baea383620113ff6a2ac17c8d63"
 
-install_bsd_64bit "Go Freebsd 64bit 1.14.15" "https://golang.org/dl/go1.14.15.freebsd-amd64.tar.gz#06b355212b788e348369e1d09bb55aed73da4b3569af5a5f8801dd88182df99f"
+install_bsd_64bit "Go Freebsd 64bit 1.14.15" "https://go.dev/dl/go1.14.15.freebsd-amd64.tar.gz#06b355212b788e348369e1d09bb55aed73da4b3569af5a5f8801dd88182df99f"
 
-install_linux_32bit "Go Linux 32bit 1.14.15" "https://golang.org/dl/go1.14.15.linux-386.tar.gz#cab962eaf954378bbb5b24f703baf3b471e9690a109082dd688593fbb6f9008e"
+install_linux_32bit "Go Linux 32bit 1.14.15" "https://go.dev/dl/go1.14.15.linux-386.tar.gz#cab962eaf954378bbb5b24f703baf3b471e9690a109082dd688593fbb6f9008e"
 
-install_linux_64bit "Go Linux 64bit 1.14.15" "https://golang.org/dl/go1.14.15.linux-amd64.tar.gz#c64a57b374a81f7cf1408d2c410a28c6f142414f1ffa9d1062de1d653b0ae0d6"
+install_linux_64bit "Go Linux 64bit 1.14.15" "https://go.dev/dl/go1.14.15.linux-amd64.tar.gz#c64a57b374a81f7cf1408d2c410a28c6f142414f1ffa9d1062de1d653b0ae0d6"
 
-install_linux_arm "Go Linux arm 1.14.15" "https://golang.org/dl/go1.14.15.linux-armv6l.tar.gz#a63960d9b9c14954e299ffe060c0574ffb91ab810837da5941853b664d0652da"
+install_linux_arm "Go Linux arm 1.14.15" "https://go.dev/dl/go1.14.15.linux-armv6l.tar.gz#a63960d9b9c14954e299ffe060c0574ffb91ab810837da5941853b664d0652da"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.14.15" "https://golang.org/dl/go1.14.15.linux-arm64.tar.gz#4d964166a189c22032521c63935437c304bb7f01673b196898cff525897a1c27"
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.15" "https://go.dev/dl/go1.14.15.linux-arm64.tar.gz#4d964166a189c22032521c63935437c304bb7f01673b196898cff525897a1c27"

--- a/plugins/go-build/share/go-build/1.14.5
+++ b/plugins/go-build/share/go-build/1.14.5
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.14.5" "https://golang.org/dl/go1.14.5.darwin-amd64.tar.gz#1d01212ac86340e6680cb36e354339920e7c6e99b4e09a9d1377a2cd2ca5f760"
+install_darwin_64bit "Go Darwin 64bit 1.14.5" "https://go.dev/dl/go1.14.5.darwin-amd64.tar.gz#1d01212ac86340e6680cb36e354339920e7c6e99b4e09a9d1377a2cd2ca5f760"
 
-install_bsd_32bit "Go Freebsd 32bit 1.14.5" "https://golang.org/dl/go1.14.5.freebsd-386.tar.gz#ac0d175ab0208c7aae2742c1f1d49bc969e4db0fb02b5ea43449a96af9859718"
+install_bsd_32bit "Go Freebsd 32bit 1.14.5" "https://go.dev/dl/go1.14.5.freebsd-386.tar.gz#ac0d175ab0208c7aae2742c1f1d49bc969e4db0fb02b5ea43449a96af9859718"
 
-install_bsd_64bit "Go Freebsd 64bit 1.14.5" "https://golang.org/dl/go1.14.5.freebsd-amd64.tar.gz#38556ad4056253ee8074eb8bb4f62ad84513ee6747573b7617ae83e848d9d733"
+install_bsd_64bit "Go Freebsd 64bit 1.14.5" "https://go.dev/dl/go1.14.5.freebsd-amd64.tar.gz#38556ad4056253ee8074eb8bb4f62ad84513ee6747573b7617ae83e848d9d733"
 
-install_linux_32bit "Go Linux 32bit 1.14.5" "https://golang.org/dl/go1.14.5.linux-386.tar.gz#a2f8e961b2eb4b477f0e938e9e6f08d1aac6d677c6d934ac1e532d5c9314bf3e"
+install_linux_32bit "Go Linux 32bit 1.14.5" "https://go.dev/dl/go1.14.5.linux-386.tar.gz#a2f8e961b2eb4b477f0e938e9e6f08d1aac6d677c6d934ac1e532d5c9314bf3e"
 
-install_linux_64bit "Go Linux 64bit 1.14.5" "https://golang.org/dl/go1.14.5.linux-amd64.tar.gz#82a1b84f16858db03231eb201f90cce2a991078dda543879b87e738e2586854b"
+install_linux_64bit "Go Linux 64bit 1.14.5" "https://go.dev/dl/go1.14.5.linux-amd64.tar.gz#82a1b84f16858db03231eb201f90cce2a991078dda543879b87e738e2586854b"
 
-install_linux_arm "Go Linux arm 1.14.5" "https://golang.org/dl/go1.14.5.linux-armv6l.tar.gz#fc99d9cea2f2699d338f7e0ceb40d89c02019eec2b6500011a8743104274a46c"
+install_linux_arm "Go Linux arm 1.14.5" "https://go.dev/dl/go1.14.5.linux-armv6l.tar.gz#fc99d9cea2f2699d338f7e0ceb40d89c02019eec2b6500011a8743104274a46c"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.14.5" "https://golang.org/dl/go1.14.5.linux-arm64.tar.gz#27a3b3ca4fd60c8680cd2235d5ca38cad41ee8c41bd61891d39a8501ada5f677"
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.5" "https://go.dev/dl/go1.14.5.linux-arm64.tar.gz#27a3b3ca4fd60c8680cd2235d5ca38cad41ee8c41bd61891d39a8501ada5f677"

--- a/plugins/go-build/share/go-build/1.14.6
+++ b/plugins/go-build/share/go-build/1.14.6
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.14.6" "https://golang.org/dl/go1.14.6.darwin-amd64.tar.gz#4832c7b6b9a2a225c557d5e8d66928230a5a8405e705ace53f6ed0ee79ddb3c4"
+install_darwin_64bit "Go Darwin 64bit 1.14.6" "https://go.dev/dl/go1.14.6.darwin-amd64.tar.gz#4832c7b6b9a2a225c557d5e8d66928230a5a8405e705ace53f6ed0ee79ddb3c4"
 
-install_bsd_32bit "Go Freebsd 32bit 1.14.6" "https://golang.org/dl/go1.14.6.freebsd-386.tar.gz#9052feba69e2b3eec11696bef2fd226aa48f98185baae5b02160111ab72e1ff0"
+install_bsd_32bit "Go Freebsd 32bit 1.14.6" "https://go.dev/dl/go1.14.6.freebsd-386.tar.gz#9052feba69e2b3eec11696bef2fd226aa48f98185baae5b02160111ab72e1ff0"
 
-install_bsd_64bit "Go Freebsd 64bit 1.14.6" "https://golang.org/dl/go1.14.6.freebsd-amd64.tar.gz#4307d83dcef4af173f35fed9a91fc7daf0443cc8dc98fa60023b4f5234ed383d"
+install_bsd_64bit "Go Freebsd 64bit 1.14.6" "https://go.dev/dl/go1.14.6.freebsd-amd64.tar.gz#4307d83dcef4af173f35fed9a91fc7daf0443cc8dc98fa60023b4f5234ed383d"
 
-install_linux_32bit "Go Linux 32bit 1.14.6" "https://golang.org/dl/go1.14.6.linux-386.tar.gz#17b2c4e26bd3a82a0a44499ae2d36e3f2155d0fe2f6b9a14ac6b7c5afac3ca6a"
+install_linux_32bit "Go Linux 32bit 1.14.6" "https://go.dev/dl/go1.14.6.linux-386.tar.gz#17b2c4e26bd3a82a0a44499ae2d36e3f2155d0fe2f6b9a14ac6b7c5afac3ca6a"
 
-install_linux_64bit "Go Linux 64bit 1.14.6" "https://golang.org/dl/go1.14.6.linux-amd64.tar.gz#5c566ddc2e0bcfc25c26a5dc44a440fcc0177f7350c1f01952b34d5989a0d287"
+install_linux_64bit "Go Linux 64bit 1.14.6" "https://go.dev/dl/go1.14.6.linux-amd64.tar.gz#5c566ddc2e0bcfc25c26a5dc44a440fcc0177f7350c1f01952b34d5989a0d287"
 
-install_linux_arm "Go Linux arm 1.14.6" "https://golang.org/dl/go1.14.6.linux-armv6l.tar.gz#cab39cc0fdf9731476a339af9d7bcd8fc661bfa323abb1ce9d1633fb31daeb07"
+install_linux_arm "Go Linux arm 1.14.6" "https://go.dev/dl/go1.14.6.linux-armv6l.tar.gz#cab39cc0fdf9731476a339af9d7bcd8fc661bfa323abb1ce9d1633fb31daeb07"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.14.6" "https://golang.org/dl/go1.14.6.linux-arm64.tar.gz#291bccfd7d7f1915599bbcc90e49d9fccfcb0004b7c62a2f5cdf0f96a09d6a3e"
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.6" "https://go.dev/dl/go1.14.6.linux-arm64.tar.gz#291bccfd7d7f1915599bbcc90e49d9fccfcb0004b7c62a2f5cdf0f96a09d6a3e"

--- a/plugins/go-build/share/go-build/1.14.7
+++ b/plugins/go-build/share/go-build/1.14.7
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.14.7" "https://golang.org/dl/go1.14.7.darwin-amd64.tar.gz#9a71abeb3de60ed33c0f90368be814d140bc868963e90fbb98ea665335ffbf9a"
+install_darwin_64bit "Go Darwin 64bit 1.14.7" "https://go.dev/dl/go1.14.7.darwin-amd64.tar.gz#9a71abeb3de60ed33c0f90368be814d140bc868963e90fbb98ea665335ffbf9a"
 
-install_bsd_32bit "Go Freebsd 32bit 1.14.7" "https://golang.org/dl/go1.14.7.freebsd-386.tar.gz#a834a20cc925fb8c1d00a7ac4b704a238902a5d23d29b3cc064d056f2eef3234"
+install_bsd_32bit "Go Freebsd 32bit 1.14.7" "https://go.dev/dl/go1.14.7.freebsd-386.tar.gz#a834a20cc925fb8c1d00a7ac4b704a238902a5d23d29b3cc064d056f2eef3234"
 
-install_bsd_64bit "Go Freebsd 64bit 1.14.7" "https://golang.org/dl/go1.14.7.freebsd-amd64.tar.gz#8a0c69f67c85a8ec457ecb9f6dbc0ff2650b0490e84caf78c66ea6ce87bd527a"
+install_bsd_64bit "Go Freebsd 64bit 1.14.7" "https://go.dev/dl/go1.14.7.freebsd-amd64.tar.gz#8a0c69f67c85a8ec457ecb9f6dbc0ff2650b0490e84caf78c66ea6ce87bd527a"
 
-install_linux_32bit "Go Linux 32bit 1.14.7" "https://golang.org/dl/go1.14.7.linux-386.tar.gz#2f5793f10bb6b08eedecd376aa3d594e10193c6b5cf198ada46200259ff76547"
+install_linux_32bit "Go Linux 32bit 1.14.7" "https://go.dev/dl/go1.14.7.linux-386.tar.gz#2f5793f10bb6b08eedecd376aa3d594e10193c6b5cf198ada46200259ff76547"
 
-install_linux_64bit "Go Linux 64bit 1.14.7" "https://golang.org/dl/go1.14.7.linux-amd64.tar.gz#4a7fa60f323ee1416a4b1425aefc37ea359e9d64df19c326a58953a97ad41ea5"
+install_linux_64bit "Go Linux 64bit 1.14.7" "https://go.dev/dl/go1.14.7.linux-amd64.tar.gz#4a7fa60f323ee1416a4b1425aefc37ea359e9d64df19c326a58953a97ad41ea5"
 
-install_linux_arm "Go Linux arm 1.14.7" "https://golang.org/dl/go1.14.7.linux-armv6l.tar.gz#fe5b6f6e441f3cb7b53ebf1a010bbebcb720ac98124984cfe2e51d72b8a58c71"
+install_linux_arm "Go Linux arm 1.14.7" "https://go.dev/dl/go1.14.7.linux-armv6l.tar.gz#fe5b6f6e441f3cb7b53ebf1a010bbebcb720ac98124984cfe2e51d72b8a58c71"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.14.7" "https://golang.org/dl/go1.14.7.linux-arm64.tar.gz#fe5b6f6e441f3cb7b53ebf1a010bbebcb720ac98124984cfe2e51d72b8a58c71"
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.7" "https://go.dev/dl/go1.14.7.linux-arm64.tar.gz#fe5b6f6e441f3cb7b53ebf1a010bbebcb720ac98124984cfe2e51d72b8a58c71"

--- a/plugins/go-build/share/go-build/1.14.8
+++ b/plugins/go-build/share/go-build/1.14.8
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.14.8" "https://golang.org/dl/go1.14.8.darwin-amd64.tar.gz#6fbfdca4e876477f1cb54df09b310e95f335e1d49556fe5c75bca02159b94c63"
+install_darwin_64bit "Go Darwin 64bit 1.14.8" "https://go.dev/dl/go1.14.8.darwin-amd64.tar.gz#6fbfdca4e876477f1cb54df09b310e95f335e1d49556fe5c75bca02159b94c63"
 
-install_bsd_32bit "Go Freebsd 32bit 1.14.8" "https://golang.org/dl/go1.14.8.freebsd-386.tar.gz#e610d966f639344e4b7415ea1a38aa088ae7cf9532d16ed2e8f1e887f4b28b98"
+install_bsd_32bit "Go Freebsd 32bit 1.14.8" "https://go.dev/dl/go1.14.8.freebsd-386.tar.gz#e610d966f639344e4b7415ea1a38aa088ae7cf9532d16ed2e8f1e887f4b28b98"
 
-install_bsd_64bit "Go Freebsd 64bit 1.14.8" "https://golang.org/dl/go1.14.8.freebsd-amd64.tar.gz#ca930a532fbfd86acc2b04007060dea74653bef9fd37aaf070bed0a265fbf12b"
+install_bsd_64bit "Go Freebsd 64bit 1.14.8" "https://go.dev/dl/go1.14.8.freebsd-amd64.tar.gz#ca930a532fbfd86acc2b04007060dea74653bef9fd37aaf070bed0a265fbf12b"
 
-install_linux_32bit "Go Linux 32bit 1.14.8" "https://golang.org/dl/go1.14.8.linux-386.tar.gz#8176ebc3a61caba3d7955cf28461268c987fea1fc11611e7031fcdf8e112a62d"
+install_linux_32bit "Go Linux 32bit 1.14.8" "https://go.dev/dl/go1.14.8.linux-386.tar.gz#8176ebc3a61caba3d7955cf28461268c987fea1fc11611e7031fcdf8e112a62d"
 
-install_linux_64bit "Go Linux 64bit 1.14.8" "https://golang.org/dl/go1.14.8.linux-amd64.tar.gz#5504e077a29d0bd6649ca7b66e317f1a4b264e960f74115d6f0f405c49a8e738"
+install_linux_64bit "Go Linux 64bit 1.14.8" "https://go.dev/dl/go1.14.8.linux-amd64.tar.gz#5504e077a29d0bd6649ca7b66e317f1a4b264e960f74115d6f0f405c49a8e738"
 
-install_linux_arm "Go Linux arm 1.14.8" "https://golang.org/dl/go1.14.8.linux-armv6l.tar.gz#5d0c7a1cf79b044ad14414676c945a0e2ed61ae8167142d4e493118a66fafcb5"
+install_linux_arm "Go Linux arm 1.14.8" "https://go.dev/dl/go1.14.8.linux-armv6l.tar.gz#5d0c7a1cf79b044ad14414676c945a0e2ed61ae8167142d4e493118a66fafcb5"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.14.8" "https://golang.org/dl/go1.14.8.linux-arm64.tar.gz#52219e5508cbd8c93070d85f5ac8f1049eac5e89399666c46aa9edd9b1112725"
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.8" "https://go.dev/dl/go1.14.8.linux-arm64.tar.gz#52219e5508cbd8c93070d85f5ac8f1049eac5e89399666c46aa9edd9b1112725"

--- a/plugins/go-build/share/go-build/1.14.9
+++ b/plugins/go-build/share/go-build/1.14.9
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.14.9" "https://golang.org/dl/go1.14.9.darwin-amd64.tar.gz#957926fd883998f3e212ccd422d4282be957204f89eefcf13ee2fdb730e1bab7"
+install_darwin_64bit "Go Darwin 64bit 1.14.9" "https://go.dev/dl/go1.14.9.darwin-amd64.tar.gz#957926fd883998f3e212ccd422d4282be957204f89eefcf13ee2fdb730e1bab7"
 
-install_bsd_32bit "Go Freebsd 32bit 1.14.9" "https://golang.org/dl/go1.14.9.freebsd-386.tar.gz#11b00fecbfaf34074194b095995c71a24205bbc1e8e23fd8c624bb34e55b655c"
+install_bsd_32bit "Go Freebsd 32bit 1.14.9" "https://go.dev/dl/go1.14.9.freebsd-386.tar.gz#11b00fecbfaf34074194b095995c71a24205bbc1e8e23fd8c624bb34e55b655c"
 
-install_bsd_64bit "Go Freebsd 64bit 1.14.9" "https://golang.org/dl/go1.14.9.freebsd-amd64.tar.gz#4dae9ca431d3c9da9834c59041a1e63eec8ad9c7f75d50e6636f92cb064a3784"
+install_bsd_64bit "Go Freebsd 64bit 1.14.9" "https://go.dev/dl/go1.14.9.freebsd-amd64.tar.gz#4dae9ca431d3c9da9834c59041a1e63eec8ad9c7f75d50e6636f92cb064a3784"
 
-install_linux_32bit "Go Linux 32bit 1.14.9" "https://golang.org/dl/go1.14.9.linux-386.tar.gz#14982ef997ec323023a11cffe1a4afc3aacd1b5edebf70a00e17b67f888d8cdb"
+install_linux_32bit "Go Linux 32bit 1.14.9" "https://go.dev/dl/go1.14.9.linux-386.tar.gz#14982ef997ec323023a11cffe1a4afc3aacd1b5edebf70a00e17b67f888d8cdb"
 
-install_linux_64bit "Go Linux 64bit 1.14.9" "https://golang.org/dl/go1.14.9.linux-amd64.tar.gz#f0d26ff572c72c9823ae752d3c81819a81a60c753201f51f89637482531c110a"
+install_linux_64bit "Go Linux 64bit 1.14.9" "https://go.dev/dl/go1.14.9.linux-amd64.tar.gz#f0d26ff572c72c9823ae752d3c81819a81a60c753201f51f89637482531c110a"
 
-install_linux_arm "Go Linux arm 1.14.9" "https://golang.org/dl/go1.14.9.linux-armv6l.tar.gz#e85dc09608dc9fc245ebc5daea0826898ac0eb0d48ed24e2300427850876c442"
+install_linux_arm "Go Linux arm 1.14.9" "https://go.dev/dl/go1.14.9.linux-armv6l.tar.gz#e85dc09608dc9fc245ebc5daea0826898ac0eb0d48ed24e2300427850876c442"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.14.9" "https://golang.org/dl/go1.14.9.linux-arm64.tar.gz#65e6cef5c474a3514e754f6a7987c49388bb85a7b370370c1318087ac35427fa"
+install_linux_arm_64bit "Go Linux arm 64bit 1.14.9" "https://go.dev/dl/go1.14.9.linux-arm64.tar.gz#65e6cef5c474a3514e754f6a7987c49388bb85a7b370370c1318087ac35427fa"

--- a/plugins/go-build/share/go-build/1.15.0
+++ b/plugins/go-build/share/go-build/1.15.0
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.0" "https://golang.org/dl/go1.15.darwin-amd64.tar.gz#8a5fb9c8587854a84957a79b9616070b63d8842d4001c3c7d86f261cd7b5ffb6"
+install_darwin_64bit "Go Darwin 64bit 1.15.0" "https://go.dev/dl/go1.15.darwin-amd64.tar.gz#8a5fb9c8587854a84957a79b9616070b63d8842d4001c3c7d86f261cd7b5ffb6"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.0" "https://golang.org/dl/go1.15.freebsd-386.tar.gz#b4591dec28b4eaf170885c6e4063970db5a4faf8bba20de6e22f1e25478ad5a9"
+install_bsd_32bit "Go Freebsd 32bit 1.15.0" "https://go.dev/dl/go1.15.freebsd-386.tar.gz#b4591dec28b4eaf170885c6e4063970db5a4faf8bba20de6e22f1e25478ad5a9"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.0" "https://golang.org/dl/go1.15.freebsd-amd64.tar.gz#5f607802e77bf14d148c3defe11b56a3e9447c2246ed96adceb8eb4bb4c1a3d6"
+install_bsd_64bit "Go Freebsd 64bit 1.15.0" "https://go.dev/dl/go1.15.freebsd-amd64.tar.gz#5f607802e77bf14d148c3defe11b56a3e9447c2246ed96adceb8eb4bb4c1a3d6"
 
-install_linux_32bit "Go Linux 32bit 1.15.0" "https://golang.org/dl/go1.15.linux-386.tar.gz#68ce979083126694ceef60233f69efe870f54af24d81a120f76265107a9e9aab"
+install_linux_32bit "Go Linux 32bit 1.15.0" "https://go.dev/dl/go1.15.linux-386.tar.gz#68ce979083126694ceef60233f69efe870f54af24d81a120f76265107a9e9aab"
 
-install_linux_64bit "Go Linux 64bit 1.15.0" "https://golang.org/dl/go1.15.linux-amd64.tar.gz#2d75848ac606061efe52a8068d0e647b35ce487a15bb52272c427df485193602"
+install_linux_64bit "Go Linux 64bit 1.15.0" "https://go.dev/dl/go1.15.linux-amd64.tar.gz#2d75848ac606061efe52a8068d0e647b35ce487a15bb52272c427df485193602"
 
-install_linux_arm "Go Linux arm 1.15.0" "https://golang.org/dl/go1.15.linux-armv6l.tar.gz#6d8914ddd25f85f2377c269ccfb359acf53adf71a42cdbf53434a7c76fa7a9bd"
+install_linux_arm "Go Linux arm 1.15.0" "https://go.dev/dl/go1.15.linux-armv6l.tar.gz#6d8914ddd25f85f2377c269ccfb359acf53adf71a42cdbf53434a7c76fa7a9bd"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.0" "https://golang.org/dl/go1.15.linux-arm64.tar.gz#7e18d92f61ddf480a4f9a57db09389ae7b9dadf68470d0cb9c00d734a0c57f8d"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.0" "https://go.dev/dl/go1.15.linux-arm64.tar.gz#7e18d92f61ddf480a4f9a57db09389ae7b9dadf68470d0cb9c00d734a0c57f8d"

--- a/plugins/go-build/share/go-build/1.15.1
+++ b/plugins/go-build/share/go-build/1.15.1
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.1" "https://golang.org/dl/go1.15.1.darwin-amd64.tar.gz#b33341df847b4a48da40d957437c87642d221dde28c6f810b1ce26b74be2f661"
+install_darwin_64bit "Go Darwin 64bit 1.15.1" "https://go.dev/dl/go1.15.1.darwin-amd64.tar.gz#b33341df847b4a48da40d957437c87642d221dde28c6f810b1ce26b74be2f661"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.1" "https://golang.org/dl/go1.15.1.freebsd-386.tar.gz#042b5f2a9eabac75f9dbd0f385e11b418fdec5fbd15b920cba5e7055d196b32b"
+install_bsd_32bit "Go Freebsd 32bit 1.15.1" "https://go.dev/dl/go1.15.1.freebsd-386.tar.gz#042b5f2a9eabac75f9dbd0f385e11b418fdec5fbd15b920cba5e7055d196b32b"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.1" "https://golang.org/dl/go1.15.1.freebsd-amd64.tar.gz#8e8b6aa8be70c9d03d0fcaddf5cc8b48f869ed34d275abb2604093087b3481b5"
+install_bsd_64bit "Go Freebsd 64bit 1.15.1" "https://go.dev/dl/go1.15.1.freebsd-amd64.tar.gz#8e8b6aa8be70c9d03d0fcaddf5cc8b48f869ed34d275abb2604093087b3481b5"
 
-install_linux_32bit "Go Linux 32bit 1.15.1" "https://golang.org/dl/go1.15.1.linux-386.tar.gz#7e0c8e9749be69c28d3333a81ce8386916ba1306b40476a43f7794dc309eaf4c"
+install_linux_32bit "Go Linux 32bit 1.15.1" "https://go.dev/dl/go1.15.1.linux-386.tar.gz#7e0c8e9749be69c28d3333a81ce8386916ba1306b40476a43f7794dc309eaf4c"
 
-install_linux_64bit "Go Linux 64bit 1.15.1" "https://golang.org/dl/go1.15.1.linux-amd64.tar.gz#70ac0dbf60a8ee9236f337ed0daa7a4c3b98f6186d4497826f68e97c0c0413f6"
+install_linux_64bit "Go Linux 64bit 1.15.1" "https://go.dev/dl/go1.15.1.linux-amd64.tar.gz#70ac0dbf60a8ee9236f337ed0daa7a4c3b98f6186d4497826f68e97c0c0413f6"
 
-install_linux_arm "Go Linux arm 1.15.1" "https://golang.org/dl/go1.15.1.linux-armv6l.tar.gz#62db2fac55309f4bc1f73577165dcb331a4c649e39bdbe04943579e0b2b0c06e"
+install_linux_arm "Go Linux arm 1.15.1" "https://go.dev/dl/go1.15.1.linux-armv6l.tar.gz#62db2fac55309f4bc1f73577165dcb331a4c649e39bdbe04943579e0b2b0c06e"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.1" "https://golang.org/dl/go1.15.1.linux-arm64.tar.gz#ca21c771d906fbba8840b3a4831b1aa118f6e09b5d028323592faba382787a03"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.1" "https://go.dev/dl/go1.15.1.linux-arm64.tar.gz#ca21c771d906fbba8840b3a4831b1aa118f6e09b5d028323592faba382787a03"

--- a/plugins/go-build/share/go-build/1.15.10
+++ b/plugins/go-build/share/go-build/1.15.10
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.10" "https://golang.org/dl/go1.15.10.darwin-amd64.tar.gz#19648b2495eade4c77797c789cd437e81ae575d84594f7c7f63d25c6ed24865e"
+install_darwin_64bit "Go Darwin 64bit 1.15.10" "https://go.dev/dl/go1.15.10.darwin-amd64.tar.gz#19648b2495eade4c77797c789cd437e81ae575d84594f7c7f63d25c6ed24865e"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.10" "https://golang.org/dl/go1.15.10.freebsd-386.tar.gz#3b86b71075e258f0f09ea025317fe78ed0e49d9da59acb5e29e67eaea835166e"
+install_bsd_32bit "Go Freebsd 32bit 1.15.10" "https://go.dev/dl/go1.15.10.freebsd-386.tar.gz#3b86b71075e258f0f09ea025317fe78ed0e49d9da59acb5e29e67eaea835166e"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.10" "https://golang.org/dl/go1.15.10.freebsd-amd64.tar.gz#eab5abfc8a1794d921b39da6e61a7638a7aaab401a645231f38238c7eaadc8b1"
+install_bsd_64bit "Go Freebsd 64bit 1.15.10" "https://go.dev/dl/go1.15.10.freebsd-amd64.tar.gz#eab5abfc8a1794d921b39da6e61a7638a7aaab401a645231f38238c7eaadc8b1"
 
-install_linux_32bit "Go Linux 32bit 1.15.10" "https://golang.org/dl/go1.15.10.linux-386.tar.gz#69a29473c9e8eded5b5885a45773e4f1b9661383ce577199c4c70efe4c67bc59"
+install_linux_32bit "Go Linux 32bit 1.15.10" "https://go.dev/dl/go1.15.10.linux-386.tar.gz#69a29473c9e8eded5b5885a45773e4f1b9661383ce577199c4c70efe4c67bc59"
 
-install_linux_64bit "Go Linux 64bit 1.15.10" "https://golang.org/dl/go1.15.10.linux-amd64.tar.gz#4aa1267517df32f2bf1cc3d55dfc27d0c6b2c2b0989449c96dd19273ccca051d"
+install_linux_64bit "Go Linux 64bit 1.15.10" "https://go.dev/dl/go1.15.10.linux-amd64.tar.gz#4aa1267517df32f2bf1cc3d55dfc27d0c6b2c2b0989449c96dd19273ccca051d"
 
-install_linux_arm "Go Linux arm 1.15.10" "https://golang.org/dl/go1.15.10.linux-armv6l.tar.gz#10739f7a87544acca49c9f1c025ae1821ce83601228a968bd7102357ae89887b"
+install_linux_arm "Go Linux arm 1.15.10" "https://go.dev/dl/go1.15.10.linux-armv6l.tar.gz#10739f7a87544acca49c9f1c025ae1821ce83601228a968bd7102357ae89887b"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.10" "https://golang.org/dl/go1.15.10.linux-arm64.tar.gz#ca3f3e84d863d8e758bfaab65430b12b6cff8f5a5648139245321d3401da64a7"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.10" "https://go.dev/dl/go1.15.10.linux-arm64.tar.gz#ca3f3e84d863d8e758bfaab65430b12b6cff8f5a5648139245321d3401da64a7"

--- a/plugins/go-build/share/go-build/1.15.11
+++ b/plugins/go-build/share/go-build/1.15.11
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.11" "https://golang.org/dl/go1.15.11.darwin-amd64.tar.gz#651c78408b2c047b7ccccb6b244c5de9eab927c87594ff6bd9540d43c9706671"
+install_darwin_64bit "Go Darwin 64bit 1.15.11" "https://go.dev/dl/go1.15.11.darwin-amd64.tar.gz#651c78408b2c047b7ccccb6b244c5de9eab927c87594ff6bd9540d43c9706671"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.11" "https://golang.org/dl/go1.15.11.freebsd-386.tar.gz#c9ac9e8e12b9a4639d8a164815d2ccab86f7c1534672c1d03933e7180d2ace5d"
+install_bsd_32bit "Go Freebsd 32bit 1.15.11" "https://go.dev/dl/go1.15.11.freebsd-386.tar.gz#c9ac9e8e12b9a4639d8a164815d2ccab86f7c1534672c1d03933e7180d2ace5d"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.11" "https://golang.org/dl/go1.15.11.freebsd-amd64.tar.gz#38fb5516e86934dc385d1b06433692034f38ed38117e8017e211a0efe55ed44e"
+install_bsd_64bit "Go Freebsd 64bit 1.15.11" "https://go.dev/dl/go1.15.11.freebsd-amd64.tar.gz#38fb5516e86934dc385d1b06433692034f38ed38117e8017e211a0efe55ed44e"
 
-install_linux_32bit "Go Linux 32bit 1.15.11" "https://golang.org/dl/go1.15.11.linux-386.tar.gz#2de51fc6873d8b688d7451cfc87443ef49404af98bbab9c8a36fb6c4bc95e4de"
+install_linux_32bit "Go Linux 32bit 1.15.11" "https://go.dev/dl/go1.15.11.linux-386.tar.gz#2de51fc6873d8b688d7451cfc87443ef49404af98bbab9c8a36fb6c4bc95e4de"
 
-install_linux_64bit "Go Linux 64bit 1.15.11" "https://golang.org/dl/go1.15.11.linux-amd64.tar.gz#8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec"
+install_linux_64bit "Go Linux 64bit 1.15.11" "https://go.dev/dl/go1.15.11.linux-amd64.tar.gz#8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec"
 
-install_linux_arm "Go Linux arm 1.15.11" "https://golang.org/dl/go1.15.11.linux-armv6l.tar.gz#dba11ed018fc7b5774ca996c4bdb847f8f9535cdc4932eb09a43c390813af4c9"
+install_linux_arm "Go Linux arm 1.15.11" "https://go.dev/dl/go1.15.11.linux-armv6l.tar.gz#dba11ed018fc7b5774ca996c4bdb847f8f9535cdc4932eb09a43c390813af4c9"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.11" "https://golang.org/dl/go1.15.11.linux-arm64.tar.gz#bfc8f07945296e97c6d28c7999d86b5cab51c7a87eb2b22ca6781c41a6bb6f2d"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.11" "https://go.dev/dl/go1.15.11.linux-arm64.tar.gz#bfc8f07945296e97c6d28c7999d86b5cab51c7a87eb2b22ca6781c41a6bb6f2d"

--- a/plugins/go-build/share/go-build/1.15.12
+++ b/plugins/go-build/share/go-build/1.15.12
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.12" "https://golang.org/dl/go1.15.12.darwin-amd64.tar.gz#05062d111062a5475f6f637018b09dc907bb6815bb156c26ebccf8d47ee35e2c"
+install_darwin_64bit "Go Darwin 64bit 1.15.12" "https://go.dev/dl/go1.15.12.darwin-amd64.tar.gz#05062d111062a5475f6f637018b09dc907bb6815bb156c26ebccf8d47ee35e2c"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.12" "https://golang.org/dl/go1.15.12.freebsd-386.tar.gz#b8153343d1c52d65c86be70f3eed2756cc2e0048a419fd9510ae4b8b99773190"
+install_bsd_32bit "Go Freebsd 32bit 1.15.12" "https://go.dev/dl/go1.15.12.freebsd-386.tar.gz#b8153343d1c52d65c86be70f3eed2756cc2e0048a419fd9510ae4b8b99773190"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.12" "https://golang.org/dl/go1.15.12.freebsd-amd64.tar.gz#a63cca04ca822041219149402cf7b23c7f2d6b5d213329c1bf90cf9af62079d1"
+install_bsd_64bit "Go Freebsd 64bit 1.15.12" "https://go.dev/dl/go1.15.12.freebsd-amd64.tar.gz#a63cca04ca822041219149402cf7b23c7f2d6b5d213329c1bf90cf9af62079d1"
 
-install_linux_32bit "Go Linux 32bit 1.15.12" "https://golang.org/dl/go1.15.12.linux-386.tar.gz#d186ccaa0080e301d35fa49a244877da6f08a1aeda3ed90438fee835538f7ece"
+install_linux_32bit "Go Linux 32bit 1.15.12" "https://go.dev/dl/go1.15.12.linux-386.tar.gz#d186ccaa0080e301d35fa49a244877da6f08a1aeda3ed90438fee835538f7ece"
 
-install_linux_64bit "Go Linux 64bit 1.15.12" "https://golang.org/dl/go1.15.12.linux-amd64.tar.gz#bbdb935699e0b24d90e2451346da76121b2412d30930eabcd80907c230d098b7"
+install_linux_64bit "Go Linux 64bit 1.15.12" "https://go.dev/dl/go1.15.12.linux-amd64.tar.gz#bbdb935699e0b24d90e2451346da76121b2412d30930eabcd80907c230d098b7"
 
-install_linux_arm "Go Linux arm 1.15.12" "https://golang.org/dl/go1.15.12.linux-armv6l.tar.gz#6a20048f7061d06f590d869a5298e8c0ffc325e8faf0bb8b6a622ad007a53028"
+install_linux_arm "Go Linux arm 1.15.12" "https://go.dev/dl/go1.15.12.linux-armv6l.tar.gz#6a20048f7061d06f590d869a5298e8c0ffc325e8faf0bb8b6a622ad007a53028"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.12" "https://golang.org/dl/go1.15.12.linux-arm64.tar.gz#a10161e6f0389c45ecd810e114acaba967ea3a4def551fcbb0b1e270996103ed"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.12" "https://go.dev/dl/go1.15.12.linux-arm64.tar.gz#a10161e6f0389c45ecd810e114acaba967ea3a4def551fcbb0b1e270996103ed"

--- a/plugins/go-build/share/go-build/1.15.13
+++ b/plugins/go-build/share/go-build/1.15.13
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.13" "https://golang.org/dl/go1.15.13.darwin-amd64.tar.gz#fc5415935430f75316374c918a20067d7a1883e4b0ffb33dc8c2ff34df6d55fe"
+install_darwin_64bit "Go Darwin 64bit 1.15.13" "https://go.dev/dl/go1.15.13.darwin-amd64.tar.gz#fc5415935430f75316374c918a20067d7a1883e4b0ffb33dc8c2ff34df6d55fe"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.13" "https://golang.org/dl/go1.15.13.freebsd-386.tar.gz#d99f07567dc97166d5a7f9f857a64e4bf3641c02bc55e8ea5e24c7d4ca6f21a7"
+install_bsd_32bit "Go Freebsd 32bit 1.15.13" "https://go.dev/dl/go1.15.13.freebsd-386.tar.gz#d99f07567dc97166d5a7f9f857a64e4bf3641c02bc55e8ea5e24c7d4ca6f21a7"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.13" "https://golang.org/dl/go1.15.13.freebsd-amd64.tar.gz#36f451d50785ebca3aa1945bdfa475ec82c58dcadb84d4f9f969fccc53588071"
+install_bsd_64bit "Go Freebsd 64bit 1.15.13" "https://go.dev/dl/go1.15.13.freebsd-amd64.tar.gz#36f451d50785ebca3aa1945bdfa475ec82c58dcadb84d4f9f969fccc53588071"
 
-install_linux_32bit "Go Linux 32bit 1.15.13" "https://golang.org/dl/go1.15.13.linux-386.tar.gz#8df80ccbbd57b108ec43066925bf02aac47bc9e0236894dbd019f26944d27399"
+install_linux_32bit "Go Linux 32bit 1.15.13" "https://go.dev/dl/go1.15.13.linux-386.tar.gz#8df80ccbbd57b108ec43066925bf02aac47bc9e0236894dbd019f26944d27399"
 
-install_linux_64bit "Go Linux 64bit 1.15.13" "https://golang.org/dl/go1.15.13.linux-amd64.tar.gz#3d3beec5fc66659018e09f40abb7274b10794229ba7c1e8bdb7d8ca77b656a13"
+install_linux_64bit "Go Linux 64bit 1.15.13" "https://go.dev/dl/go1.15.13.linux-amd64.tar.gz#3d3beec5fc66659018e09f40abb7274b10794229ba7c1e8bdb7d8ca77b656a13"
 
-install_linux_arm "Go Linux arm 1.15.13" "https://golang.org/dl/go1.15.13.linux-armv6l.tar.gz#00ff453f102c67ff6b790ba0cb10cecf73c8e8bbd9d913e5978ac8cc6323132f"
+install_linux_arm "Go Linux arm 1.15.13" "https://go.dev/dl/go1.15.13.linux-armv6l.tar.gz#00ff453f102c67ff6b790ba0cb10cecf73c8e8bbd9d913e5978ac8cc6323132f"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.13" "https://golang.org/dl/go1.15.13.linux-arm64.tar.gz#f3989dca4dea5fbadfec253d7c24e4111773b203e677abb1f01e768a99cc14e6"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.13" "https://go.dev/dl/go1.15.13.linux-arm64.tar.gz#f3989dca4dea5fbadfec253d7c24e4111773b203e677abb1f01e768a99cc14e6"

--- a/plugins/go-build/share/go-build/1.15.14
+++ b/plugins/go-build/share/go-build/1.15.14
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.14" "https://golang.org/dl/go1.15.14.darwin-amd64.tar.gz#86b350467d5a09e717129d107072d242ec1cf9a1511acd46efe4ec825f6fe3dd"
+install_darwin_64bit "Go Darwin 64bit 1.15.14" "https://go.dev/dl/go1.15.14.darwin-amd64.tar.gz#86b350467d5a09e717129d107072d242ec1cf9a1511acd46efe4ec825f6fe3dd"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.14" "https://golang.org/dl/go1.15.14.freebsd-386.tar.gz#520bd7eae9af3b769a5f4273f0b8e11951fe0376f179907e76e16bac880aff1b"
+install_bsd_32bit "Go Freebsd 32bit 1.15.14" "https://go.dev/dl/go1.15.14.freebsd-386.tar.gz#520bd7eae9af3b769a5f4273f0b8e11951fe0376f179907e76e16bac880aff1b"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.14" "https://golang.org/dl/go1.15.14.freebsd-amd64.tar.gz#9ac2f0d4e35cb1275c10c83cb86c4a24374f34682298ca2d6cfff86349d21859"
+install_bsd_64bit "Go Freebsd 64bit 1.15.14" "https://go.dev/dl/go1.15.14.freebsd-amd64.tar.gz#9ac2f0d4e35cb1275c10c83cb86c4a24374f34682298ca2d6cfff86349d21859"
 
-install_linux_32bit "Go Linux 32bit 1.15.14" "https://golang.org/dl/go1.15.14.linux-386.tar.gz#0216746103b8da20b23f91a86795bcf72e12428b2d07dfd3279a14b070ceaa74"
+install_linux_32bit "Go Linux 32bit 1.15.14" "https://go.dev/dl/go1.15.14.linux-386.tar.gz#0216746103b8da20b23f91a86795bcf72e12428b2d07dfd3279a14b070ceaa74"
 
-install_linux_64bit "Go Linux 64bit 1.15.14" "https://golang.org/dl/go1.15.14.linux-amd64.tar.gz#6f5410c113b803f437d7a1ee6f8f124100e536cc7361920f7e640fedf7add72d"
+install_linux_64bit "Go Linux 64bit 1.15.14" "https://go.dev/dl/go1.15.14.linux-amd64.tar.gz#6f5410c113b803f437d7a1ee6f8f124100e536cc7361920f7e640fedf7add72d"
 
-install_linux_arm "Go Linux arm 1.15.14" "https://golang.org/dl/go1.15.14.linux-armv6l.tar.gz#a40fe975caf82daef311e22902eb4aeda1f0bd63a782c1ebd81911abed6c187b"
+install_linux_arm "Go Linux arm 1.15.14" "https://go.dev/dl/go1.15.14.linux-armv6l.tar.gz#a40fe975caf82daef311e22902eb4aeda1f0bd63a782c1ebd81911abed6c187b"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.14" "https://golang.org/dl/go1.15.14.linux-arm64.tar.gz#84e483d1ec7dae591f28f218485f8f67877412e24b8cea626bebf25b6d299c7f"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.14" "https://go.dev/dl/go1.15.14.linux-arm64.tar.gz#84e483d1ec7dae591f28f218485f8f67877412e24b8cea626bebf25b6d299c7f"

--- a/plugins/go-build/share/go-build/1.15.15
+++ b/plugins/go-build/share/go-build/1.15.15
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.15" "https://golang.org/dl/go1.15.15.darwin-amd64.tar.gz#2f4c119524450ee94062a1ce7112fb88ce0fe4bb0303a302e002183a550c25c2"
+install_darwin_64bit "Go Darwin 64bit 1.15.15" "https://go.dev/dl/go1.15.15.darwin-amd64.tar.gz#2f4c119524450ee94062a1ce7112fb88ce0fe4bb0303a302e002183a550c25c2"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.15" "https://golang.org/dl/go1.15.15.freebsd-386.tar.gz#7174078a53e330cf351dc20bed6682033f44066d8aed754139bcaef52e53c214"
+install_bsd_32bit "Go Freebsd 32bit 1.15.15" "https://go.dev/dl/go1.15.15.freebsd-386.tar.gz#7174078a53e330cf351dc20bed6682033f44066d8aed754139bcaef52e53c214"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.15" "https://golang.org/dl/go1.15.15.freebsd-amd64.tar.gz#1f80a20419b2618182ef5b9615dd990b32b952d81b354b373c6fd304527bb70c"
+install_bsd_64bit "Go Freebsd 64bit 1.15.15" "https://go.dev/dl/go1.15.15.freebsd-amd64.tar.gz#1f80a20419b2618182ef5b9615dd990b32b952d81b354b373c6fd304527bb70c"
 
-install_linux_32bit "Go Linux 32bit 1.15.15" "https://golang.org/dl/go1.15.15.linux-386.tar.gz#3310fb0e48b0907bb520f6e3c6dcff63cc0913b92a76456f12980d0eb13b77d4"
+install_linux_32bit "Go Linux 32bit 1.15.15" "https://go.dev/dl/go1.15.15.linux-386.tar.gz#3310fb0e48b0907bb520f6e3c6dcff63cc0913b92a76456f12980d0eb13b77d4"
 
-install_linux_64bit "Go Linux 64bit 1.15.15" "https://golang.org/dl/go1.15.15.linux-amd64.tar.gz#0885cf046a9f099e260d98d9ec5d19ea9328f34c8dc4956e1d3cd87daaddb345"
+install_linux_64bit "Go Linux 64bit 1.15.15" "https://go.dev/dl/go1.15.15.linux-amd64.tar.gz#0885cf046a9f099e260d98d9ec5d19ea9328f34c8dc4956e1d3cd87daaddb345"
 
-install_linux_arm "Go Linux arm 1.15.15" "https://golang.org/dl/go1.15.15.linux-armv6l.tar.gz#7192603af50afb23c9d8cd14d2b2c19e0985a34d3eca685fa098df7893000d19"
+install_linux_arm "Go Linux arm 1.15.15" "https://go.dev/dl/go1.15.15.linux-armv6l.tar.gz#7192603af50afb23c9d8cd14d2b2c19e0985a34d3eca685fa098df7893000d19"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.15" "https://golang.org/dl/go1.15.15.linux-arm64.tar.gz#714abb01af210473dd6af331094ad6847162eff81a7fc7241d24f5a85496c9fa"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.15" "https://go.dev/dl/go1.15.15.linux-arm64.tar.gz#714abb01af210473dd6af331094ad6847162eff81a7fc7241d24f5a85496c9fa"

--- a/plugins/go-build/share/go-build/1.15.2
+++ b/plugins/go-build/share/go-build/1.15.2
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.2" "https://golang.org/dl/go1.15.2.darwin-amd64.tar.gz#9bd39600d9fa1fa4a5ccce8761d249f7421cffe671376f791293c4138f3d7c62"
+install_darwin_64bit "Go Darwin 64bit 1.15.2" "https://go.dev/dl/go1.15.2.darwin-amd64.tar.gz#9bd39600d9fa1fa4a5ccce8761d249f7421cffe671376f791293c4138f3d7c62"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.2" "https://golang.org/dl/go1.15.2.freebsd-386.tar.gz#286beeb2d2c57707d9b3f3dcace0ff0f5b804dda8916daa4e712b9174fd270e4"
+install_bsd_32bit "Go Freebsd 32bit 1.15.2" "https://go.dev/dl/go1.15.2.freebsd-386.tar.gz#286beeb2d2c57707d9b3f3dcace0ff0f5b804dda8916daa4e712b9174fd270e4"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.2" "https://golang.org/dl/go1.15.2.freebsd-amd64.tar.gz#53a03ac989666be77e26d2720721021a3f29a22d93a1db86a4240369799043e0"
+install_bsd_64bit "Go Freebsd 64bit 1.15.2" "https://go.dev/dl/go1.15.2.freebsd-amd64.tar.gz#53a03ac989666be77e26d2720721021a3f29a22d93a1db86a4240369799043e0"
 
-install_linux_32bit "Go Linux 32bit 1.15.2" "https://golang.org/dl/go1.15.2.linux-386.tar.gz#5a91080469df6b91f1022bdfb0ca75e01ca50387950b13518def3d0a7f6af9f1"
+install_linux_32bit "Go Linux 32bit 1.15.2" "https://go.dev/dl/go1.15.2.linux-386.tar.gz#5a91080469df6b91f1022bdfb0ca75e01ca50387950b13518def3d0a7f6af9f1"
 
-install_linux_64bit "Go Linux 64bit 1.15.2" "https://golang.org/dl/go1.15.2.linux-amd64.tar.gz#b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552"
+install_linux_64bit "Go Linux 64bit 1.15.2" "https://go.dev/dl/go1.15.2.linux-amd64.tar.gz#b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552"
 
-install_linux_arm "Go Linux arm 1.15.2" "https://golang.org/dl/go1.15.2.linux-armv6l.tar.gz#c12e2afdcb21e530d332d4994919f856dd2a676e9d67034c7d6fefcb241412d9"
+install_linux_arm "Go Linux arm 1.15.2" "https://go.dev/dl/go1.15.2.linux-armv6l.tar.gz#c12e2afdcb21e530d332d4994919f856dd2a676e9d67034c7d6fefcb241412d9"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.2" "https://golang.org/dl/go1.15.2.linux-arm64.tar.gz#c8ec460cc82d61604b048f9439c06bd591722efce5cd48f49e19b5f6226bd36d"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.2" "https://go.dev/dl/go1.15.2.linux-arm64.tar.gz#c8ec460cc82d61604b048f9439c06bd591722efce5cd48f49e19b5f6226bd36d"

--- a/plugins/go-build/share/go-build/1.15.3
+++ b/plugins/go-build/share/go-build/1.15.3
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.3" "https://golang.org/dl/go1.15.3.darwin-amd64.tar.gz#2e045043a28a2834e10edeb64c0cffd080a3525016fab1898d5624b57312a698"
+install_darwin_64bit "Go Darwin 64bit 1.15.3" "https://go.dev/dl/go1.15.3.darwin-amd64.tar.gz#2e045043a28a2834e10edeb64c0cffd080a3525016fab1898d5624b57312a698"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.3" "https://golang.org/dl/go1.15.3.freebsd-386.tar.gz#c86545a72b879f26e4bf261ef0b09fdae47359ac92415cf028e66ca437d9ba41"
+install_bsd_32bit "Go Freebsd 32bit 1.15.3" "https://go.dev/dl/go1.15.3.freebsd-386.tar.gz#c86545a72b879f26e4bf261ef0b09fdae47359ac92415cf028e66ca437d9ba41"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.3" "https://golang.org/dl/go1.15.3.freebsd-amd64.tar.gz#bd8b717679a58ac4ef069fbb03705b42d7816cd516b6805ba43ca26fa7e61712"
+install_bsd_64bit "Go Freebsd 64bit 1.15.3" "https://go.dev/dl/go1.15.3.freebsd-amd64.tar.gz#bd8b717679a58ac4ef069fbb03705b42d7816cd516b6805ba43ca26fa7e61712"
 
-install_linux_32bit "Go Linux 32bit 1.15.3" "https://golang.org/dl/go1.15.3.linux-386.tar.gz#e2f4f9ccfebd38b112fe84572af44bb2fa230d605fcec84def9498095c1bd6ce"
+install_linux_32bit "Go Linux 32bit 1.15.3" "https://go.dev/dl/go1.15.3.linux-386.tar.gz#e2f4f9ccfebd38b112fe84572af44bb2fa230d605fcec84def9498095c1bd6ce"
 
-install_linux_64bit "Go Linux 64bit 1.15.3" "https://golang.org/dl/go1.15.3.linux-amd64.tar.gz#010a88df924a81ec21b293b5da8f9b11c176d27c0ee3962dc1738d2352d3c02d"
+install_linux_64bit "Go Linux 64bit 1.15.3" "https://go.dev/dl/go1.15.3.linux-amd64.tar.gz#010a88df924a81ec21b293b5da8f9b11c176d27c0ee3962dc1738d2352d3c02d"
 
-install_linux_arm "Go Linux arm 1.15.3" "https://golang.org/dl/go1.15.3.linux-armv6l.tar.gz#aacb49968d08e222c83dea7307b4523c3ae498a5d2e91cd0e480ef3f198ffef6"
+install_linux_arm "Go Linux arm 1.15.3" "https://go.dev/dl/go1.15.3.linux-armv6l.tar.gz#aacb49968d08e222c83dea7307b4523c3ae498a5d2e91cd0e480ef3f198ffef6"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.3" "https://golang.org/dl/go1.15.3.linux-arm64.tar.gz#b8b88a87ada918ef5189fa5938ef4c46a4f61952a34317612aaac705f4275f80"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.3" "https://go.dev/dl/go1.15.3.linux-arm64.tar.gz#b8b88a87ada918ef5189fa5938ef4c46a4f61952a34317612aaac705f4275f80"

--- a/plugins/go-build/share/go-build/1.15.4
+++ b/plugins/go-build/share/go-build/1.15.4
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.4" "https://golang.org/dl/go1.15.4.darwin-amd64.tar.gz#aaf8c5323e0557211680960a8f51bedf98ab9a368775a687d6cf1f0079232b1d"
+install_darwin_64bit "Go Darwin 64bit 1.15.4" "https://go.dev/dl/go1.15.4.darwin-amd64.tar.gz#aaf8c5323e0557211680960a8f51bedf98ab9a368775a687d6cf1f0079232b1d"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.4" "https://golang.org/dl/go1.15.4.freebsd-386.tar.gz#37874f0df879d72972c684006ff3826a9fa89400f01afcc89576e767d27781e2"
+install_bsd_32bit "Go Freebsd 32bit 1.15.4" "https://go.dev/dl/go1.15.4.freebsd-386.tar.gz#37874f0df879d72972c684006ff3826a9fa89400f01afcc89576e767d27781e2"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.4" "https://golang.org/dl/go1.15.4.freebsd-amd64.tar.gz#c1a9d20dc190ed40ec78d5e77337b1db187a9634e7c485505a8b9afbcc1e4738"
+install_bsd_64bit "Go Freebsd 64bit 1.15.4" "https://go.dev/dl/go1.15.4.freebsd-amd64.tar.gz#c1a9d20dc190ed40ec78d5e77337b1db187a9634e7c485505a8b9afbcc1e4738"
 
-install_linux_32bit "Go Linux 32bit 1.15.4" "https://golang.org/dl/go1.15.4.linux-386.tar.gz#6b2f6d8afddfb198bf0e36044084dc4db4cb0be1107375240b34d215aa5ff6ad"
+install_linux_32bit "Go Linux 32bit 1.15.4" "https://go.dev/dl/go1.15.4.linux-386.tar.gz#6b2f6d8afddfb198bf0e36044084dc4db4cb0be1107375240b34d215aa5ff6ad"
 
-install_linux_64bit "Go Linux 64bit 1.15.4" "https://golang.org/dl/go1.15.4.linux-amd64.tar.gz#eb61005f0b932c93b424a3a4eaa67d72196c79129d9a3ea8578047683e2c80d5"
+install_linux_64bit "Go Linux 64bit 1.15.4" "https://go.dev/dl/go1.15.4.linux-amd64.tar.gz#eb61005f0b932c93b424a3a4eaa67d72196c79129d9a3ea8578047683e2c80d5"
 
-install_linux_arm "Go Linux arm 1.15.4" "https://golang.org/dl/go1.15.4.linux-armv6l.tar.gz#fe449ad3e121472e5db2f70becc0fef9d1a7188616c0605ada63f1e3bbad280e"
+install_linux_arm "Go Linux arm 1.15.4" "https://go.dev/dl/go1.15.4.linux-armv6l.tar.gz#fe449ad3e121472e5db2f70becc0fef9d1a7188616c0605ada63f1e3bbad280e"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.4" "https://golang.org/dl/go1.15.4.linux-arm64.tar.gz#6f083b453484fc5f95afb345547a58ccc957cde91348b7a7c68f5b060e488c85"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.4" "https://go.dev/dl/go1.15.4.linux-arm64.tar.gz#6f083b453484fc5f95afb345547a58ccc957cde91348b7a7c68f5b060e488c85"

--- a/plugins/go-build/share/go-build/1.15.5
+++ b/plugins/go-build/share/go-build/1.15.5
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.5" "https://golang.org/dl/go1.15.5.darwin-amd64.tar.gz#359a4334b8c8f5e3067e5a76f16419791ac3fef4613d8e8e1eac0b9719915f6d"
+install_darwin_64bit "Go Darwin 64bit 1.15.5" "https://go.dev/dl/go1.15.5.darwin-amd64.tar.gz#359a4334b8c8f5e3067e5a76f16419791ac3fef4613d8e8e1eac0b9719915f6d"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.5" "https://golang.org/dl/go1.15.5.freebsd-386.tar.gz#d4e6b4a4b22a00ab9048fea6b44ae8626345cbc6a83325872b357d8eb11baefb"
+install_bsd_32bit "Go Freebsd 32bit 1.15.5" "https://go.dev/dl/go1.15.5.freebsd-386.tar.gz#d4e6b4a4b22a00ab9048fea6b44ae8626345cbc6a83325872b357d8eb11baefb"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.5" "https://golang.org/dl/go1.15.5.freebsd-amd64.tar.gz#ae25e356167b8f38468205c01b88f8319fb07e6b127d05a3f7bb6af9ab1ca27b"
+install_bsd_64bit "Go Freebsd 64bit 1.15.5" "https://go.dev/dl/go1.15.5.freebsd-amd64.tar.gz#ae25e356167b8f38468205c01b88f8319fb07e6b127d05a3f7bb6af9ab1ca27b"
 
-install_linux_32bit "Go Linux 32bit 1.15.5" "https://golang.org/dl/go1.15.5.linux-386.tar.gz#4c8179d406136979724c71732009c7e2e7c794dbeaaa2a043c00da34d4be0559"
+install_linux_32bit "Go Linux 32bit 1.15.5" "https://go.dev/dl/go1.15.5.linux-386.tar.gz#4c8179d406136979724c71732009c7e2e7c794dbeaaa2a043c00da34d4be0559"
 
-install_linux_64bit "Go Linux 64bit 1.15.5" "https://golang.org/dl/go1.15.5.linux-amd64.tar.gz#9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d"
+install_linux_64bit "Go Linux 64bit 1.15.5" "https://go.dev/dl/go1.15.5.linux-amd64.tar.gz#9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d"
 
-install_linux_arm "Go Linux arm 1.15.5" "https://golang.org/dl/go1.15.5.linux-armv6l.tar.gz#5ea6456620d3efed5dda99238c7f23866eafdd915e5348736e631bc283c0238a"
+install_linux_arm "Go Linux arm 1.15.5" "https://go.dev/dl/go1.15.5.linux-armv6l.tar.gz#5ea6456620d3efed5dda99238c7f23866eafdd915e5348736e631bc283c0238a"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.5" "https://golang.org/dl/go1.15.5.linux-arm64.tar.gz#a72a0b036beb4193a0214bca3fca4c5d68a38a4ccf098c909f7ce8bf08567c48"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.5" "https://go.dev/dl/go1.15.5.linux-arm64.tar.gz#a72a0b036beb4193a0214bca3fca4c5d68a38a4ccf098c909f7ce8bf08567c48"

--- a/plugins/go-build/share/go-build/1.15.6
+++ b/plugins/go-build/share/go-build/1.15.6
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.6" "https://golang.org/dl/go1.15.6.darwin-amd64.tar.gz#940a73b45993a3bae5792cf324140dded34af97c548af4864d22fd6d49f3bd9f"
+install_darwin_64bit "Go Darwin 64bit 1.15.6" "https://go.dev/dl/go1.15.6.darwin-amd64.tar.gz#940a73b45993a3bae5792cf324140dded34af97c548af4864d22fd6d49f3bd9f"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.6" "https://golang.org/dl/go1.15.6.freebsd-386.tar.gz#9d9dd5c217c1392f1b2ed5e03e1c71bf4cf8553884e57a38e68fd37fdcfe31a8"
+install_bsd_32bit "Go Freebsd 32bit 1.15.6" "https://go.dev/dl/go1.15.6.freebsd-386.tar.gz#9d9dd5c217c1392f1b2ed5e03e1c71bf4cf8553884e57a38e68fd37fdcfe31a8"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.6" "https://golang.org/dl/go1.15.6.freebsd-amd64.tar.gz#609f065d855aed5a0b40ef0245aacbcc0b4b7882dc3b1e75ae50576cf25265ee"
+install_bsd_64bit "Go Freebsd 64bit 1.15.6" "https://go.dev/dl/go1.15.6.freebsd-amd64.tar.gz#609f065d855aed5a0b40ef0245aacbcc0b4b7882dc3b1e75ae50576cf25265ee"
 
-install_linux_32bit "Go Linux 32bit 1.15.6" "https://golang.org/dl/go1.15.6.linux-386.tar.gz#ad187f02158b9a9013ef03f41d14aa69c402477f178825a3940280814bcbb755"
+install_linux_32bit "Go Linux 32bit 1.15.6" "https://go.dev/dl/go1.15.6.linux-386.tar.gz#ad187f02158b9a9013ef03f41d14aa69c402477f178825a3940280814bcbb755"
 
-install_linux_64bit "Go Linux 64bit 1.15.6" "https://golang.org/dl/go1.15.6.linux-amd64.tar.gz#3918e6cc85e7eaaa6f859f1bdbaac772e7a825b0eb423c63d3ae68b21f84b844"
+install_linux_64bit "Go Linux 64bit 1.15.6" "https://go.dev/dl/go1.15.6.linux-amd64.tar.gz#3918e6cc85e7eaaa6f859f1bdbaac772e7a825b0eb423c63d3ae68b21f84b844"
 
-install_linux_arm "Go Linux arm 1.15.6" "https://golang.org/dl/go1.15.6.linux-armv6l.tar.gz#40ba9a57764e374195018ef37c38a5fbac9bbce908eab436370631a84bfc5788"
+install_linux_arm "Go Linux arm 1.15.6" "https://go.dev/dl/go1.15.6.linux-armv6l.tar.gz#40ba9a57764e374195018ef37c38a5fbac9bbce908eab436370631a84bfc5788"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.6" "https://golang.org/dl/go1.15.6.linux-arm64.tar.gz#f87515b9744154ffe31182da9341d0a61eb0795551173d242c8cad209239e492"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.6" "https://go.dev/dl/go1.15.6.linux-arm64.tar.gz#f87515b9744154ffe31182da9341d0a61eb0795551173d242c8cad209239e492"

--- a/plugins/go-build/share/go-build/1.15.7
+++ b/plugins/go-build/share/go-build/1.15.7
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.7" "https://golang.org/dl/go1.15.7.darwin-amd64.tar.gz#af423736fffded2b588bab13b8963ad071eb47600ec83d0304a9a3ab95ef49a0"
+install_darwin_64bit "Go Darwin 64bit 1.15.7" "https://go.dev/dl/go1.15.7.darwin-amd64.tar.gz#af423736fffded2b588bab13b8963ad071eb47600ec83d0304a9a3ab95ef49a0"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.7" "https://golang.org/dl/go1.15.7.freebsd-386.tar.gz#fbb952ca77ed922c8d98bcd6801e3fd4104f2e2df435dd6e4e47ff0c0bd93130"
+install_bsd_32bit "Go Freebsd 32bit 1.15.7" "https://go.dev/dl/go1.15.7.freebsd-386.tar.gz#fbb952ca77ed922c8d98bcd6801e3fd4104f2e2df435dd6e4e47ff0c0bd93130"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.7" "https://golang.org/dl/go1.15.7.freebsd-amd64.tar.gz#201d12f92424c18914f4e934edad65a110882cbb6c634e0c73c55bbc2a1afc8c"
+install_bsd_64bit "Go Freebsd 64bit 1.15.7" "https://go.dev/dl/go1.15.7.freebsd-amd64.tar.gz#201d12f92424c18914f4e934edad65a110882cbb6c634e0c73c55bbc2a1afc8c"
 
-install_linux_32bit "Go Linux 32bit 1.15.7" "https://golang.org/dl/go1.15.7.linux-386.tar.gz#519e5d7518376bc6b87afc04f16e72db66d9bc08641d9b4385ecf1f30e55e64c"
+install_linux_32bit "Go Linux 32bit 1.15.7" "https://go.dev/dl/go1.15.7.linux-386.tar.gz#519e5d7518376bc6b87afc04f16e72db66d9bc08641d9b4385ecf1f30e55e64c"
 
-install_linux_64bit "Go Linux 64bit 1.15.7" "https://golang.org/dl/go1.15.7.linux-amd64.tar.gz#0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3"
+install_linux_64bit "Go Linux 64bit 1.15.7" "https://go.dev/dl/go1.15.7.linux-amd64.tar.gz#0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3"
 
-install_linux_arm "Go Linux arm 1.15.7" "https://golang.org/dl/go1.15.7.linux-armv6l.tar.gz#8ab192799a191eb3752079ab17efff12d1d7dd0e965cf84dcbf08d55542e27d3"
+install_linux_arm "Go Linux arm 1.15.7" "https://go.dev/dl/go1.15.7.linux-armv6l.tar.gz#8ab192799a191eb3752079ab17efff12d1d7dd0e965cf84dcbf08d55542e27d3"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.7" "https://golang.org/dl/go1.15.7.linux-arm64.tar.gz#bca4af0c20f86521dfabf3b39fa2f1ceeeb11cebf7e90bdf1de2618c40628539"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.7" "https://go.dev/dl/go1.15.7.linux-arm64.tar.gz#bca4af0c20f86521dfabf3b39fa2f1ceeeb11cebf7e90bdf1de2618c40628539"

--- a/plugins/go-build/share/go-build/1.15.8
+++ b/plugins/go-build/share/go-build/1.15.8
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.8" "https://golang.org/dl/go1.15.8.darwin-amd64.tar.gz#7df8977d3befd2ec41479abed1c93aac93cb320dcbe4808950d28948911da854"
+install_darwin_64bit "Go Darwin 64bit 1.15.8" "https://go.dev/dl/go1.15.8.darwin-amd64.tar.gz#7df8977d3befd2ec41479abed1c93aac93cb320dcbe4808950d28948911da854"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.8" "https://golang.org/dl/go1.15.8.freebsd-386.tar.gz#46fbf0fe03910569113989bf608e56f847df685efccdcee29d8ab3b9752211f8"
+install_bsd_32bit "Go Freebsd 32bit 1.15.8" "https://go.dev/dl/go1.15.8.freebsd-386.tar.gz#46fbf0fe03910569113989bf608e56f847df685efccdcee29d8ab3b9752211f8"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.8" "https://golang.org/dl/go1.15.8.freebsd-amd64.tar.gz#ec5b0e690593f8d6e1964221b1a95b2a3efdedcfd3562f4113cd1c0b6180a5ee"
+install_bsd_64bit "Go Freebsd 64bit 1.15.8" "https://go.dev/dl/go1.15.8.freebsd-amd64.tar.gz#ec5b0e690593f8d6e1964221b1a95b2a3efdedcfd3562f4113cd1c0b6180a5ee"
 
-install_linux_32bit "Go Linux 32bit 1.15.8" "https://golang.org/dl/go1.15.8.linux-386.tar.gz#a0cc9df6d04f89af8396278d171087894a453a03a950b0f60a4ac18b480f758f"
+install_linux_32bit "Go Linux 32bit 1.15.8" "https://go.dev/dl/go1.15.8.linux-386.tar.gz#a0cc9df6d04f89af8396278d171087894a453a03a950b0f60a4ac18b480f758f"
 
-install_linux_64bit "Go Linux 64bit 1.15.8" "https://golang.org/dl/go1.15.8.linux-amd64.tar.gz#d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b"
+install_linux_64bit "Go Linux 64bit 1.15.8" "https://go.dev/dl/go1.15.8.linux-amd64.tar.gz#d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b"
 
-install_linux_arm "Go Linux arm 1.15.8" "https://golang.org/dl/go1.15.8.linux-armv6l.tar.gz#708c398cb9e5029cfd5b654370978bf0e797d4d4a71153c06c7378db7e249a53"
+install_linux_arm "Go Linux arm 1.15.8" "https://go.dev/dl/go1.15.8.linux-armv6l.tar.gz#708c398cb9e5029cfd5b654370978bf0e797d4d4a71153c06c7378db7e249a53"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.8" "https://golang.org/dl/go1.15.8.linux-arm64.tar.gz#0e31ea4bf53496b0f0809730520dee98c0ae5c530f3701a19df0ba0a327bf3d2"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.8" "https://go.dev/dl/go1.15.8.linux-arm64.tar.gz#0e31ea4bf53496b0f0809730520dee98c0ae5c530f3701a19df0ba0a327bf3d2"

--- a/plugins/go-build/share/go-build/1.15.9
+++ b/plugins/go-build/share/go-build/1.15.9
@@ -1,13 +1,13 @@
-install_darwin_64bit "Go Darwin 64bit 1.15.9" "https://golang.org/dl/go1.15.9.darwin-amd64.tar.gz#1a7b20801933050490a6114392b6c842f3c4774bb43e15240c1faf98a01d645a"
+install_darwin_64bit "Go Darwin 64bit 1.15.9" "https://go.dev/dl/go1.15.9.darwin-amd64.tar.gz#1a7b20801933050490a6114392b6c842f3c4774bb43e15240c1faf98a01d645a"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15.9" "https://golang.org/dl/go1.15.9.freebsd-386.tar.gz#59ae769d9331c8339d2e2606260beb34030e4e9d5b3b0a727b225ef8615f7fef"
+install_bsd_32bit "Go Freebsd 32bit 1.15.9" "https://go.dev/dl/go1.15.9.freebsd-386.tar.gz#59ae769d9331c8339d2e2606260beb34030e4e9d5b3b0a727b225ef8615f7fef"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15.9" "https://golang.org/dl/go1.15.9.freebsd-amd64.tar.gz#fb094473efce8df290cf0a78dba8dbf5c76462851eeba3efb5f579746d6117e3"
+install_bsd_64bit "Go Freebsd 64bit 1.15.9" "https://go.dev/dl/go1.15.9.freebsd-amd64.tar.gz#fb094473efce8df290cf0a78dba8dbf5c76462851eeba3efb5f579746d6117e3"
 
-install_linux_32bit "Go Linux 32bit 1.15.9" "https://golang.org/dl/go1.15.9.linux-386.tar.gz#469868ac51391b84e153d09c82dacf2c75bf81b96dc13c9bee15fdd50b3406de"
+install_linux_32bit "Go Linux 32bit 1.15.9" "https://go.dev/dl/go1.15.9.linux-386.tar.gz#469868ac51391b84e153d09c82dacf2c75bf81b96dc13c9bee15fdd50b3406de"
 
-install_linux_64bit "Go Linux 64bit 1.15.9" "https://golang.org/dl/go1.15.9.linux-amd64.tar.gz#a55f3e75bc1098045851d40ea74f9d77efc7958e9af85131a96ca387d38b1834"
+install_linux_64bit "Go Linux 64bit 1.15.9" "https://go.dev/dl/go1.15.9.linux-amd64.tar.gz#a55f3e75bc1098045851d40ea74f9d77efc7958e9af85131a96ca387d38b1834"
 
-install_linux_arm "Go Linux arm 1.15.9" "https://golang.org/dl/go1.15.9.linux-armv6l.tar.gz#9dac54ad8afe282bd18b09d6ed0fad3b663187f914db2e43ee1b6968135ef01d"
+install_linux_arm "Go Linux arm 1.15.9" "https://go.dev/dl/go1.15.9.linux-armv6l.tar.gz#9dac54ad8afe282bd18b09d6ed0fad3b663187f914db2e43ee1b6968135ef01d"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.15.9" "https://golang.org/dl/go1.15.9.linux-arm64.tar.gz#8ea5f3718abde696b4762882b5a9753a8ec148c9b32e3d37e5f2e52a1f9b12ca"
+install_linux_arm_64bit "Go Linux arm 64bit 1.15.9" "https://go.dev/dl/go1.15.9.linux-arm64.tar.gz#8ea5f3718abde696b4762882b5a9753a8ec148c9b32e3d37e5f2e52a1f9b12ca"

--- a/plugins/go-build/share/go-build/1.15rc2
+++ b/plugins/go-build/share/go-build/1.15rc2
@@ -1,11 +1,11 @@
-install_darwin_64bit "Go Darwin 64bit 1.15rc2" "https://golang.org/dl/go1.15rc2.darwin-amd64.tar.gz#b07775d30e023c1570b1ba74892fc792834436c790fbb0dbb19ebaae9c155105"
+install_darwin_64bit "Go Darwin 64bit 1.15rc2" "https://go.dev/dl/go1.15rc2.darwin-amd64.tar.gz#b07775d30e023c1570b1ba74892fc792834436c790fbb0dbb19ebaae9c155105"
 
-install_bsd_32bit "Go Freebsd 32bit 1.15rc2" "https://golang.org/dl/go1.15rc2.freebsd-386.tar.gz#7d0fafd526c161242265103d674e4b77ec5dae95fe3a8853e45454633bed5022"
+install_bsd_32bit "Go Freebsd 32bit 1.15rc2" "https://go.dev/dl/go1.15rc2.freebsd-386.tar.gz#7d0fafd526c161242265103d674e4b77ec5dae95fe3a8853e45454633bed5022"
 
-install_bsd_64bit "Go Freebsd 64bit 1.15rc2" "https://golang.org/dl/go1.15rc2.freebsd-amd64.tar.gz#1f021399526442de11034a8db1bb9ede793078217d3d104775cfe65940122f0e"
+install_bsd_64bit "Go Freebsd 64bit 1.15rc2" "https://go.dev/dl/go1.15rc2.freebsd-amd64.tar.gz#1f021399526442de11034a8db1bb9ede793078217d3d104775cfe65940122f0e"
 
-install_linux_32bit "Go Linux 32bit 1.15rc2" "https://golang.org/dl/go1.15rc2.linux-386.tar.gz#9c1f1ed42bd5f776f3585e39e3ba165a9b8ac8fde45dafbb6e41e04bae44bb3d"
+install_linux_32bit "Go Linux 32bit 1.15rc2" "https://go.dev/dl/go1.15rc2.linux-386.tar.gz#9c1f1ed42bd5f776f3585e39e3ba165a9b8ac8fde45dafbb6e41e04bae44bb3d"
 
-install_linux_64bit "Go Linux 64bit 1.15rc2" "https://golang.org/dl/go1.15rc2.linux-amd64.tar.gz#f41a08f630f018bc5d9fd100bd9899516e4965356c78165157eb0eda9a17ac09"
+install_linux_64bit "Go Linux 64bit 1.15rc2" "https://go.dev/dl/go1.15rc2.linux-amd64.tar.gz#f41a08f630f018bc5d9fd100bd9899516e4965356c78165157eb0eda9a17ac09"
 
-install_linux_arm "Go Linux arm 1.15rc2" "https://golang.org/dl/go1.15rc2.linux-armv6l.tar.gz#60d4d7723ef55d49bbf8326f37011f967048ae9167ef462ee4b9af311c4f3244"
+install_linux_arm "Go Linux arm 1.15rc2" "https://go.dev/dl/go1.15rc2.linux-armv6l.tar.gz#60d4d7723ef55d49bbf8326f37011f967048ae9167ef462ee4b9af311c4f3244"

--- a/plugins/go-build/share/go-build/1.16.0
+++ b/plugins/go-build/share/go-build/1.16.0
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.16.0" "https://golang.org/dl/go1.16.darwin-amd64.tar.gz#6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8"
+install_darwin_64bit "Go Darwin 64bit 1.16.0" "https://go.dev/dl/go1.16.darwin-amd64.tar.gz#6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8"
 
-install_darwin_arm "Go Darwin arm 1.16.0" "https://golang.org/dl/go1.16.darwin-arm64.tar.gz#4dac57c00168d30bbd02d95131d5de9ca88e04f2c5a29a404576f30ae9b54810"
+install_darwin_arm "Go Darwin arm 1.16.0" "https://go.dev/dl/go1.16.darwin-arm64.tar.gz#4dac57c00168d30bbd02d95131d5de9ca88e04f2c5a29a404576f30ae9b54810"
 
-install_bsd_32bit "Go Freebsd 32bit 1.16.0" "https://golang.org/dl/go1.16.freebsd-386.tar.gz#d7d6c70b05a7c2f68b48aab5ab8cb5116b8444c9ddad131673b152e7cff7c726"
+install_bsd_32bit "Go Freebsd 32bit 1.16.0" "https://go.dev/dl/go1.16.freebsd-386.tar.gz#d7d6c70b05a7c2f68b48aab5ab8cb5116b8444c9ddad131673b152e7cff7c726"
 
-install_bsd_64bit "Go Freebsd 64bit 1.16.0" "https://golang.org/dl/go1.16.freebsd-amd64.tar.gz#40b03216f6945fb6883a50604fc7f409a83f62171607229a9c598e701e684f8a"
+install_bsd_64bit "Go Freebsd 64bit 1.16.0" "https://go.dev/dl/go1.16.freebsd-amd64.tar.gz#40b03216f6945fb6883a50604fc7f409a83f62171607229a9c598e701e684f8a"
 
-install_linux_32bit "Go Linux 32bit 1.16.0" "https://golang.org/dl/go1.16.linux-386.tar.gz#ea435a1ac6d497b03e367fdfb74b33e961d813883468080f6e239b3b03bea6aa"
+install_linux_32bit "Go Linux 32bit 1.16.0" "https://go.dev/dl/go1.16.linux-386.tar.gz#ea435a1ac6d497b03e367fdfb74b33e961d813883468080f6e239b3b03bea6aa"
 
-install_linux_64bit "Go Linux 64bit 1.16.0" "https://golang.org/dl/go1.16.linux-amd64.tar.gz#013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2"
+install_linux_64bit "Go Linux 64bit 1.16.0" "https://go.dev/dl/go1.16.linux-amd64.tar.gz#013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2"
 
-install_linux_arm "Go Linux arm 1.16.0" "https://golang.org/dl/go1.16.linux-armv6l.tar.gz#d1d9404b1dbd77afa2bdc70934e10fbfcf7d785c372efc29462bb7d83d0a32fd"
+install_linux_arm "Go Linux arm 1.16.0" "https://go.dev/dl/go1.16.linux-armv6l.tar.gz#d1d9404b1dbd77afa2bdc70934e10fbfcf7d785c372efc29462bb7d83d0a32fd"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.16.0" "https://golang.org/dl/go1.16.linux-arm64.tar.gz#3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098"
+install_linux_arm_64bit "Go Linux arm 64bit 1.16.0" "https://go.dev/dl/go1.16.linux-arm64.tar.gz#3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098"

--- a/plugins/go-build/share/go-build/1.16.1
+++ b/plugins/go-build/share/go-build/1.16.1
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.16.1" "https://golang.org/dl/go1.16.1.darwin-amd64.tar.gz#a760929667253cdaa5b10117f536a912be2b0be1006215ff86e957f98f76fd58"
+install_darwin_64bit "Go Darwin 64bit 1.16.1" "https://go.dev/dl/go1.16.1.darwin-amd64.tar.gz#a760929667253cdaa5b10117f536a912be2b0be1006215ff86e957f98f76fd58"
 
-install_darwin_arm "Go Darwin arm 1.16.1" "https://golang.org/dl/go1.16.1.darwin-arm64.tar.gz#de2847f49faac2d0608b4afc324cbb3029a496c946db616c294d26082e45f32d"
+install_darwin_arm "Go Darwin arm 1.16.1" "https://go.dev/dl/go1.16.1.darwin-arm64.tar.gz#de2847f49faac2d0608b4afc324cbb3029a496c946db616c294d26082e45f32d"
 
-install_bsd_32bit "Go Freebsd 32bit 1.16.1" "https://golang.org/dl/go1.16.1.freebsd-386.tar.gz#cec49fba5d6341f07ddd97b2dc91d40a79e27b36eed0461177f632b54da72b1e"
+install_bsd_32bit "Go Freebsd 32bit 1.16.1" "https://go.dev/dl/go1.16.1.freebsd-386.tar.gz#cec49fba5d6341f07ddd97b2dc91d40a79e27b36eed0461177f632b54da72b1e"
 
-install_bsd_64bit "Go Freebsd 64bit 1.16.1" "https://golang.org/dl/go1.16.1.freebsd-amd64.tar.gz#e03eafde19a7ccc5d24f2051a56bbe9a5bc21c0c04cbc0ada9d05417b737b0ca"
+install_bsd_64bit "Go Freebsd 64bit 1.16.1" "https://go.dev/dl/go1.16.1.freebsd-amd64.tar.gz#e03eafde19a7ccc5d24f2051a56bbe9a5bc21c0c04cbc0ada9d05417b737b0ca"
 
-install_linux_32bit "Go Linux 32bit 1.16.1" "https://golang.org/dl/go1.16.1.linux-386.tar.gz#de050a1161fe450968e9db139f48685312657297065e81508ced7ca7cb61d913"
+install_linux_32bit "Go Linux 32bit 1.16.1" "https://go.dev/dl/go1.16.1.linux-386.tar.gz#de050a1161fe450968e9db139f48685312657297065e81508ced7ca7cb61d913"
 
-install_linux_64bit "Go Linux 64bit 1.16.1" "https://golang.org/dl/go1.16.1.linux-amd64.tar.gz#3edc22f8332231c3ba8be246f184b736b8d28f06ce24f08168d8ecf052549769"
+install_linux_64bit "Go Linux 64bit 1.16.1" "https://go.dev/dl/go1.16.1.linux-amd64.tar.gz#3edc22f8332231c3ba8be246f184b736b8d28f06ce24f08168d8ecf052549769"
 
-install_linux_arm "Go Linux arm 1.16.1" "https://golang.org/dl/go1.16.1.linux-armv6l.tar.gz#c49e1680de0d72917e6a16423adcc0c57a86e6ec2324510ddeb4bff35e46ecb4"
+install_linux_arm "Go Linux arm 1.16.1" "https://go.dev/dl/go1.16.1.linux-armv6l.tar.gz#c49e1680de0d72917e6a16423adcc0c57a86e6ec2324510ddeb4bff35e46ecb4"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.16.1" "https://golang.org/dl/go1.16.1.linux-arm64.tar.gz#fa8a6034e51e5cceaa477027d44c2f9a2f1d9540e8ce881014c526c11290a180"
+install_linux_arm_64bit "Go Linux arm 64bit 1.16.1" "https://go.dev/dl/go1.16.1.linux-arm64.tar.gz#fa8a6034e51e5cceaa477027d44c2f9a2f1d9540e8ce881014c526c11290a180"

--- a/plugins/go-build/share/go-build/1.16.10
+++ b/plugins/go-build/share/go-build/1.16.10
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.16.10" "https://golang.org/dl/go1.16.10.darwin-amd64.tar.gz#895a3fe6d720297ce16272f41c198648da8675bb244ab6d60003265c176b6c48"
+install_darwin_64bit "Go Darwin 64bit 1.16.10" "https://go.dev/dl/go1.16.10.darwin-amd64.tar.gz#895a3fe6d720297ce16272f41c198648da8675bb244ab6d60003265c176b6c48"
 
-install_darwin_arm "Go Darwin arm 1.16.10" "https://golang.org/dl/go1.16.10.darwin-arm64.tar.gz#850970c6b381b9a3e6da969bf1baddb8fe003ed90315082e5cb3afbbc87812d0"
+install_darwin_arm "Go Darwin arm 1.16.10" "https://go.dev/dl/go1.16.10.darwin-arm64.tar.gz#850970c6b381b9a3e6da969bf1baddb8fe003ed90315082e5cb3afbbc87812d0"
 
-install_bsd_32bit "Go Freebsd 32bit 1.16.10" "https://golang.org/dl/go1.16.10.freebsd-386.tar.gz#84c400643b67614403fccfa245fa0ede4f473663530f0990f8a8bd7fb9bb6465"
+install_bsd_32bit "Go Freebsd 32bit 1.16.10" "https://go.dev/dl/go1.16.10.freebsd-386.tar.gz#84c400643b67614403fccfa245fa0ede4f473663530f0990f8a8bd7fb9bb6465"
 
-install_bsd_64bit "Go Freebsd 64bit 1.16.10" "https://golang.org/dl/go1.16.10.freebsd-amd64.tar.gz#59c86209d43020e93b8164cac36ac73d5830fc26ac7328e55e33c4b47b48fea1"
+install_bsd_64bit "Go Freebsd 64bit 1.16.10" "https://go.dev/dl/go1.16.10.freebsd-amd64.tar.gz#59c86209d43020e93b8164cac36ac73d5830fc26ac7328e55e33c4b47b48fea1"
 
-install_linux_32bit "Go Linux 32bit 1.16.10" "https://golang.org/dl/go1.16.10.linux-386.tar.gz#03c2a0287f56662f57264ef16fd461ecf60f001c74c58f3d5dc4cd708d08a5b3"
+install_linux_32bit "Go Linux 32bit 1.16.10" "https://go.dev/dl/go1.16.10.linux-386.tar.gz#03c2a0287f56662f57264ef16fd461ecf60f001c74c58f3d5dc4cd708d08a5b3"
 
-install_linux_64bit "Go Linux 64bit 1.16.10" "https://golang.org/dl/go1.16.10.linux-amd64.tar.gz#414cd18ce1d193769b9e97d2401ad718755ab47816e13b2a1cde203d263b55cf"
+install_linux_64bit "Go Linux 64bit 1.16.10" "https://go.dev/dl/go1.16.10.linux-amd64.tar.gz#414cd18ce1d193769b9e97d2401ad718755ab47816e13b2a1cde203d263b55cf"
 
-install_linux_arm "Go Linux arm 1.16.10" "https://golang.org/dl/go1.16.10.linux-armv6l.tar.gz#ae3cf64fce3d0b45cf0bb1854f9093205e684c472a7f2db8c37cd5e37a4c2e86"
+install_linux_arm "Go Linux arm 1.16.10" "https://go.dev/dl/go1.16.10.linux-armv6l.tar.gz#ae3cf64fce3d0b45cf0bb1854f9093205e684c472a7f2db8c37cd5e37a4c2e86"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.16.10" "https://golang.org/dl/go1.16.10.linux-arm64.tar.gz#bfe1d4b82626c742b4690a832ca59a21e3d702161556f3c0ed26dffb368927e9"
+install_linux_arm_64bit "Go Linux arm 64bit 1.16.10" "https://go.dev/dl/go1.16.10.linux-arm64.tar.gz#bfe1d4b82626c742b4690a832ca59a21e3d702161556f3c0ed26dffb368927e9"

--- a/plugins/go-build/share/go-build/1.16.2
+++ b/plugins/go-build/share/go-build/1.16.2
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.16.2" "https://golang.org/dl/go1.16.2.darwin-amd64.tar.gz#c98cde81517c5daf427f3071412f39d5bc58f6120e90a0d94cc51480fa04dbc1"
+install_darwin_64bit "Go Darwin 64bit 1.16.2" "https://go.dev/dl/go1.16.2.darwin-amd64.tar.gz#c98cde81517c5daf427f3071412f39d5bc58f6120e90a0d94cc51480fa04dbc1"
 
-install_darwin_arm "Go Darwin arm 1.16.2" "https://golang.org/dl/go1.16.2.darwin-arm64.tar.gz#9238b5187aedd1a049bb88abef15aa2ea3fee3458be0e982bea0dac5e5f0d811"
+install_darwin_arm "Go Darwin arm 1.16.2" "https://go.dev/dl/go1.16.2.darwin-arm64.tar.gz#9238b5187aedd1a049bb88abef15aa2ea3fee3458be0e982bea0dac5e5f0d811"
 
-install_bsd_32bit "Go Freebsd 32bit 1.16.2" "https://golang.org/dl/go1.16.2.freebsd-386.tar.gz#09cd0eae0a3e8766984e775cf76c9a902bbf8347c1fa21c45be019690cedef82"
+install_bsd_32bit "Go Freebsd 32bit 1.16.2" "https://go.dev/dl/go1.16.2.freebsd-386.tar.gz#09cd0eae0a3e8766984e775cf76c9a902bbf8347c1fa21c45be019690cedef82"
 
-install_bsd_64bit "Go Freebsd 64bit 1.16.2" "https://golang.org/dl/go1.16.2.freebsd-amd64.tar.gz#b0b0a5dc9e69b0f7da7cb0e0123efef9e6f344161574f21c7a401d3df37d2dd6"
+install_bsd_64bit "Go Freebsd 64bit 1.16.2" "https://go.dev/dl/go1.16.2.freebsd-amd64.tar.gz#b0b0a5dc9e69b0f7da7cb0e0123efef9e6f344161574f21c7a401d3df37d2dd6"
 
-install_linux_32bit "Go Linux 32bit 1.16.2" "https://golang.org/dl/go1.16.2.linux-386.tar.gz#3638abf8e8272a4ddc3e5189487c932d680abfb151e2c48ae18c9a04a90ded73"
+install_linux_32bit "Go Linux 32bit 1.16.2" "https://go.dev/dl/go1.16.2.linux-386.tar.gz#3638abf8e8272a4ddc3e5189487c932d680abfb151e2c48ae18c9a04a90ded73"
 
-install_linux_64bit "Go Linux 64bit 1.16.2" "https://golang.org/dl/go1.16.2.linux-amd64.tar.gz#542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8"
+install_linux_64bit "Go Linux 64bit 1.16.2" "https://go.dev/dl/go1.16.2.linux-amd64.tar.gz#542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8"
 
-install_linux_arm "Go Linux arm 1.16.2" "https://golang.org/dl/go1.16.2.linux-armv6l.tar.gz#49765b1ac36f77a84ce8186b08713c3811db5426e4ecfaa4344453e12d756c22"
+install_linux_arm "Go Linux arm 1.16.2" "https://go.dev/dl/go1.16.2.linux-armv6l.tar.gz#49765b1ac36f77a84ce8186b08713c3811db5426e4ecfaa4344453e12d756c22"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.16.2" "https://golang.org/dl/go1.16.2.linux-arm64.tar.gz#6924601d998a0917694fd14261347e3798bd2ad6b13c4d7f2edd70c9d57f62ab"
+install_linux_arm_64bit "Go Linux arm 64bit 1.16.2" "https://go.dev/dl/go1.16.2.linux-arm64.tar.gz#6924601d998a0917694fd14261347e3798bd2ad6b13c4d7f2edd70c9d57f62ab"

--- a/plugins/go-build/share/go-build/1.16.3
+++ b/plugins/go-build/share/go-build/1.16.3
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.16.3" "https://golang.org/dl/go1.16.3.darwin-amd64.tar.gz#6bb1cf421f8abc2a9a4e39140b7397cdae6aca3e8d36dcff39a1a77f4f1170ac"
+install_darwin_64bit "Go Darwin 64bit 1.16.3" "https://go.dev/dl/go1.16.3.darwin-amd64.tar.gz#6bb1cf421f8abc2a9a4e39140b7397cdae6aca3e8d36dcff39a1a77f4f1170ac"
 
-install_darwin_arm "Go Darwin arm 1.16.3" "https://golang.org/dl/go1.16.3.darwin-arm64.tar.gz#f4e96bbcd5d2d1942f5b55d9e4ab19564da4fad192012f6d7b0b9b055ba4208f"
+install_darwin_arm "Go Darwin arm 1.16.3" "https://go.dev/dl/go1.16.3.darwin-arm64.tar.gz#f4e96bbcd5d2d1942f5b55d9e4ab19564da4fad192012f6d7b0b9b055ba4208f"
 
-install_bsd_32bit "Go Freebsd 32bit 1.16.3" "https://golang.org/dl/go1.16.3.freebsd-386.tar.gz#31ecd11d497684fa8b0f01ba784590c4c760943665fdc4fe0adaa1405c71736c"
+install_bsd_32bit "Go Freebsd 32bit 1.16.3" "https://go.dev/dl/go1.16.3.freebsd-386.tar.gz#31ecd11d497684fa8b0f01ba784590c4c760943665fdc4fe0adaa1405c71736c"
 
-install_bsd_64bit "Go Freebsd 64bit 1.16.3" "https://golang.org/dl/go1.16.3.freebsd-amd64.tar.gz#ffbd920b309e62e807457b11d80e8c17fefe3ef6de423aaba4b1e270b2ca4c3d"
+install_bsd_64bit "Go Freebsd 64bit 1.16.3" "https://go.dev/dl/go1.16.3.freebsd-amd64.tar.gz#ffbd920b309e62e807457b11d80e8c17fefe3ef6de423aaba4b1e270b2ca4c3d"
 
-install_linux_32bit "Go Linux 32bit 1.16.3" "https://golang.org/dl/go1.16.3.linux-386.tar.gz#48b2d1481db756c88c18b1f064dbfc3e265ce4a775a23177ca17e25d13a24c5d"
+install_linux_32bit "Go Linux 32bit 1.16.3" "https://go.dev/dl/go1.16.3.linux-386.tar.gz#48b2d1481db756c88c18b1f064dbfc3e265ce4a775a23177ca17e25d13a24c5d"
 
-install_linux_64bit "Go Linux 64bit 1.16.3" "https://golang.org/dl/go1.16.3.linux-amd64.tar.gz#951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2"
+install_linux_64bit "Go Linux 64bit 1.16.3" "https://go.dev/dl/go1.16.3.linux-amd64.tar.gz#951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2"
 
-install_linux_arm "Go Linux arm 1.16.3" "https://golang.org/dl/go1.16.3.linux-armv6l.tar.gz#0dae30385e3564a557dac7f12a63eedc73543e6da0f6017990e214ce8cc8797c"
+install_linux_arm "Go Linux arm 1.16.3" "https://go.dev/dl/go1.16.3.linux-armv6l.tar.gz#0dae30385e3564a557dac7f12a63eedc73543e6da0f6017990e214ce8cc8797c"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.16.3" "https://golang.org/dl/go1.16.3.linux-arm64.tar.gz#566b1d6f17d2bc4ad5f81486f0df44f3088c3ed47a3bec4099d8ed9939e90d5d"
+install_linux_arm_64bit "Go Linux arm 64bit 1.16.3" "https://go.dev/dl/go1.16.3.linux-arm64.tar.gz#566b1d6f17d2bc4ad5f81486f0df44f3088c3ed47a3bec4099d8ed9939e90d5d"

--- a/plugins/go-build/share/go-build/1.16.4
+++ b/plugins/go-build/share/go-build/1.16.4
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.16.4" "https://golang.org/dl/go1.16.4.darwin-amd64.tar.gz#18fe94775763db3878717393b6d41371b0b45206055e49b3838328120c977d13"
+install_darwin_64bit "Go Darwin 64bit 1.16.4" "https://go.dev/dl/go1.16.4.darwin-amd64.tar.gz#18fe94775763db3878717393b6d41371b0b45206055e49b3838328120c977d13"
 
-install_darwin_arm "Go Darwin arm 1.16.4" "https://golang.org/dl/go1.16.4.darwin-arm64.tar.gz#cb6b972cc42e669f3585c648198cd5b6f6d7a0811d413ad64b50c02ba06ccc3a"
+install_darwin_arm "Go Darwin arm 1.16.4" "https://go.dev/dl/go1.16.4.darwin-arm64.tar.gz#cb6b972cc42e669f3585c648198cd5b6f6d7a0811d413ad64b50c02ba06ccc3a"
 
-install_bsd_32bit "Go Freebsd 32bit 1.16.4" "https://golang.org/dl/go1.16.4.freebsd-386.tar.gz#7cf2bc8a175d6d656861165bfc554f92dc78d2abf5afe5631db3579555d97409"
+install_bsd_32bit "Go Freebsd 32bit 1.16.4" "https://go.dev/dl/go1.16.4.freebsd-386.tar.gz#7cf2bc8a175d6d656861165bfc554f92dc78d2abf5afe5631db3579555d97409"
 
-install_bsd_64bit "Go Freebsd 64bit 1.16.4" "https://golang.org/dl/go1.16.4.freebsd-amd64.tar.gz#ccdd2b76de1941b60734408fda0d750aaa69330d8a07430eed4c56bdb3502f6f"
+install_bsd_64bit "Go Freebsd 64bit 1.16.4" "https://go.dev/dl/go1.16.4.freebsd-amd64.tar.gz#ccdd2b76de1941b60734408fda0d750aaa69330d8a07430eed4c56bdb3502f6f"
 
-install_linux_32bit "Go Linux 32bit 1.16.4" "https://golang.org/dl/go1.16.4.linux-386.tar.gz#cd1b146ef6e9006f27dd99e9687773e7fef30e8c985b7d41bff33e955a3bb53a"
+install_linux_32bit "Go Linux 32bit 1.16.4" "https://go.dev/dl/go1.16.4.linux-386.tar.gz#cd1b146ef6e9006f27dd99e9687773e7fef30e8c985b7d41bff33e955a3bb53a"
 
-install_linux_64bit "Go Linux 64bit 1.16.4" "https://golang.org/dl/go1.16.4.linux-amd64.tar.gz#7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59"
+install_linux_64bit "Go Linux 64bit 1.16.4" "https://go.dev/dl/go1.16.4.linux-amd64.tar.gz#7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59"
 
-install_linux_arm "Go Linux arm 1.16.4" "https://golang.org/dl/go1.16.4.linux-armv6l.tar.gz#a53391a800ddec749ee90d38992babb27b95cfb864027350c737b9aa8e069494"
+install_linux_arm "Go Linux arm 1.16.4" "https://go.dev/dl/go1.16.4.linux-armv6l.tar.gz#a53391a800ddec749ee90d38992babb27b95cfb864027350c737b9aa8e069494"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.16.4" "https://golang.org/dl/go1.16.4.linux-arm64.tar.gz#8b18eb05ddda2652d69ab1b1dd1f40dd731799f43c6a58b512ad01ae5b5bba21"
+install_linux_arm_64bit "Go Linux arm 64bit 1.16.4" "https://go.dev/dl/go1.16.4.linux-arm64.tar.gz#8b18eb05ddda2652d69ab1b1dd1f40dd731799f43c6a58b512ad01ae5b5bba21"

--- a/plugins/go-build/share/go-build/1.16.5
+++ b/plugins/go-build/share/go-build/1.16.5
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.16.5" "https://golang.org/dl/go1.16.5.darwin-amd64.tar.gz#be761716d5bfc958a5367440f68ba6563509da2f539ad1e1864bd42fe553f277"
+install_darwin_64bit "Go Darwin 64bit 1.16.5" "https://go.dev/dl/go1.16.5.darwin-amd64.tar.gz#be761716d5bfc958a5367440f68ba6563509da2f539ad1e1864bd42fe553f277"
 
-install_darwin_arm "Go Darwin arm 1.16.5" "https://golang.org/dl/go1.16.5.darwin-arm64.tar.gz#7b1bed9b63d69f1caa14a8d6911fbd743e8c37e21ed4e5b5afdbbaa80d070059"
+install_darwin_arm "Go Darwin arm 1.16.5" "https://go.dev/dl/go1.16.5.darwin-arm64.tar.gz#7b1bed9b63d69f1caa14a8d6911fbd743e8c37e21ed4e5b5afdbbaa80d070059"
 
-install_bsd_32bit "Go Freebsd 32bit 1.16.5" "https://golang.org/dl/go1.16.5.freebsd-386.tar.gz#d2c6a5d17200c70160d5a79b23320f7802fb5e2620fa58ab0b43c147fc018192"
+install_bsd_32bit "Go Freebsd 32bit 1.16.5" "https://go.dev/dl/go1.16.5.freebsd-386.tar.gz#d2c6a5d17200c70160d5a79b23320f7802fb5e2620fa58ab0b43c147fc018192"
 
-install_bsd_64bit "Go Freebsd 64bit 1.16.5" "https://golang.org/dl/go1.16.5.freebsd-amd64.tar.gz#7110fe0c16e45641cf5a457b1bf1cba76275abca298a4dc93b60b4b33697310f"
+install_bsd_64bit "Go Freebsd 64bit 1.16.5" "https://go.dev/dl/go1.16.5.freebsd-amd64.tar.gz#7110fe0c16e45641cf5a457b1bf1cba76275abca298a4dc93b60b4b33697310f"
 
-install_linux_32bit "Go Linux 32bit 1.16.5" "https://golang.org/dl/go1.16.5.linux-386.tar.gz#a37c6b71d0b673fe8dfeb2a8b3de78824f05d680ad32b7ac6b58c573fa6695de"
+install_linux_32bit "Go Linux 32bit 1.16.5" "https://go.dev/dl/go1.16.5.linux-386.tar.gz#a37c6b71d0b673fe8dfeb2a8b3de78824f05d680ad32b7ac6b58c573fa6695de"
 
-install_linux_64bit "Go Linux 64bit 1.16.5" "https://golang.org/dl/go1.16.5.linux-amd64.tar.gz#b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061"
+install_linux_64bit "Go Linux 64bit 1.16.5" "https://go.dev/dl/go1.16.5.linux-amd64.tar.gz#b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061"
 
-install_linux_arm "Go Linux arm 1.16.5" "https://golang.org/dl/go1.16.5.linux-armv6l.tar.gz#93cacacfbe87e3106b5bf5821de106f0f0a43c8bd1029826d44445c15df795a5"
+install_linux_arm "Go Linux arm 1.16.5" "https://go.dev/dl/go1.16.5.linux-armv6l.tar.gz#93cacacfbe87e3106b5bf5821de106f0f0a43c8bd1029826d44445c15df795a5"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.16.5" "https://golang.org/dl/go1.16.5.linux-arm64.tar.gz#d5446b46ef6f36fdffa852f73dfbbe78c1ddf010b99fa4964944b9ae8b4d6799"
+install_linux_arm_64bit "Go Linux arm 64bit 1.16.5" "https://go.dev/dl/go1.16.5.linux-arm64.tar.gz#d5446b46ef6f36fdffa852f73dfbbe78c1ddf010b99fa4964944b9ae8b4d6799"

--- a/plugins/go-build/share/go-build/1.16.6
+++ b/plugins/go-build/share/go-build/1.16.6
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.16.6" "https://golang.org/dl/go1.16.6.darwin-amd64.tar.gz#e4e83e7c6891baa00062ed37273ce95835f0be77ad8203a29ec56dbf3d87508a"
+install_darwin_64bit "Go Darwin 64bit 1.16.6" "https://go.dev/dl/go1.16.6.darwin-amd64.tar.gz#e4e83e7c6891baa00062ed37273ce95835f0be77ad8203a29ec56dbf3d87508a"
 
-install_darwin_arm "Go Darwin arm 1.16.6" "https://golang.org/dl/go1.16.6.darwin-arm64.tar.gz#17bb7e8fb6f46ce3ac7851466d62f8985f2fef975eed8f59c236a0cc0c220dc5"
+install_darwin_arm "Go Darwin arm 1.16.6" "https://go.dev/dl/go1.16.6.darwin-arm64.tar.gz#17bb7e8fb6f46ce3ac7851466d62f8985f2fef975eed8f59c236a0cc0c220dc5"
 
-install_bsd_32bit "Go Freebsd 32bit 1.16.6" "https://golang.org/dl/go1.16.6.freebsd-386.tar.gz#0c54c675a67a28e205f02dc903f1f0e611e621cbdf46ff5c4e84f9c4bb396f85"
+install_bsd_32bit "Go Freebsd 32bit 1.16.6" "https://go.dev/dl/go1.16.6.freebsd-386.tar.gz#0c54c675a67a28e205f02dc903f1f0e611e621cbdf46ff5c4e84f9c4bb396f85"
 
-install_bsd_64bit "Go Freebsd 64bit 1.16.6" "https://golang.org/dl/go1.16.6.freebsd-amd64.tar.gz#49b17ebb37429b88f90c5b3592070db277f6ffb25fb4f3b4800c73cf2f8ea66d"
+install_bsd_64bit "Go Freebsd 64bit 1.16.6" "https://go.dev/dl/go1.16.6.freebsd-amd64.tar.gz#49b17ebb37429b88f90c5b3592070db277f6ffb25fb4f3b4800c73cf2f8ea66d"
 
-install_linux_32bit "Go Linux 32bit 1.16.6" "https://golang.org/dl/go1.16.6.linux-386.tar.gz#33d028b6d2a4abeb74cccd55024500ae49d5edfb08a30665db0b49cd1052c37e"
+install_linux_32bit "Go Linux 32bit 1.16.6" "https://go.dev/dl/go1.16.6.linux-386.tar.gz#33d028b6d2a4abeb74cccd55024500ae49d5edfb08a30665db0b49cd1052c37e"
 
-install_linux_64bit "Go Linux 64bit 1.16.6" "https://golang.org/dl/go1.16.6.linux-amd64.tar.gz#be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"
+install_linux_64bit "Go Linux 64bit 1.16.6" "https://go.dev/dl/go1.16.6.linux-amd64.tar.gz#be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"
 
-install_linux_arm "Go Linux arm 1.16.6" "https://golang.org/dl/go1.16.6.linux-armv6l.tar.gz#b1ca342e81897da3f25da4e75ae29b267db1674fe7222d9bfc4c666bcf6fce69"
+install_linux_arm "Go Linux arm 1.16.6" "https://go.dev/dl/go1.16.6.linux-armv6l.tar.gz#b1ca342e81897da3f25da4e75ae29b267db1674fe7222d9bfc4c666bcf6fce69"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.16.6" "https://golang.org/dl/go1.16.6.linux-arm64.tar.gz#9e38047463da6daecab9017cd0599f33f84991e68263752cfab49253bbc98c30"
+install_linux_arm_64bit "Go Linux arm 64bit 1.16.6" "https://go.dev/dl/go1.16.6.linux-arm64.tar.gz#9e38047463da6daecab9017cd0599f33f84991e68263752cfab49253bbc98c30"

--- a/plugins/go-build/share/go-build/1.16.7
+++ b/plugins/go-build/share/go-build/1.16.7
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.16.7" "https://golang.org/dl/go1.16.7.darwin-amd64.tar.gz#8018bf556e833912d455fab7ea279caa542239b6675c6b3861e9002380c70080"
+install_darwin_64bit "Go Darwin 64bit 1.16.7" "https://go.dev/dl/go1.16.7.darwin-amd64.tar.gz#8018bf556e833912d455fab7ea279caa542239b6675c6b3861e9002380c70080"
 
-install_darwin_arm "Go Darwin arm 1.16.7" "https://golang.org/dl/go1.16.7.darwin-arm64.tar.gz#7721706560d6a17b80b1f68efc0ebef27028bd51547127362ae0c0dac287b24b"
+install_darwin_arm "Go Darwin arm 1.16.7" "https://go.dev/dl/go1.16.7.darwin-arm64.tar.gz#7721706560d6a17b80b1f68efc0ebef27028bd51547127362ae0c0dac287b24b"
 
-install_bsd_32bit "Go Freebsd 32bit 1.16.7" "https://golang.org/dl/go1.16.7.freebsd-386.tar.gz#09d2db7b6e8636cce9af249d75ffaaf5f1fda7042725f46e43e8c3e9e012da4f"
+install_bsd_32bit "Go Freebsd 32bit 1.16.7" "https://go.dev/dl/go1.16.7.freebsd-386.tar.gz#09d2db7b6e8636cce9af249d75ffaaf5f1fda7042725f46e43e8c3e9e012da4f"
 
-install_bsd_64bit "Go Freebsd 64bit 1.16.7" "https://golang.org/dl/go1.16.7.freebsd-amd64.tar.gz#cf43ecac8a68c040354e8a45ba167ebc631091976ac370b6f1e444623bc77f37"
+install_bsd_64bit "Go Freebsd 64bit 1.16.7" "https://go.dev/dl/go1.16.7.freebsd-amd64.tar.gz#cf43ecac8a68c040354e8a45ba167ebc631091976ac370b6f1e444623bc77f37"
 
-install_linux_32bit "Go Linux 32bit 1.16.7" "https://golang.org/dl/go1.16.7.linux-386.tar.gz#5c0c8891fa88993f2193fbc9dd5cca6c250c89aa8c12bbaa382b6ff38139bcc3"
+install_linux_32bit "Go Linux 32bit 1.16.7" "https://go.dev/dl/go1.16.7.linux-386.tar.gz#5c0c8891fa88993f2193fbc9dd5cca6c250c89aa8c12bbaa382b6ff38139bcc3"
 
-install_linux_64bit "Go Linux 64bit 1.16.7" "https://golang.org/dl/go1.16.7.linux-amd64.tar.gz#7fe7a73f55ba3e2285da36f8b085e5c0159e9564ef5f63ee0ed6b818ade8ef04"
+install_linux_64bit "Go Linux 64bit 1.16.7" "https://go.dev/dl/go1.16.7.linux-amd64.tar.gz#7fe7a73f55ba3e2285da36f8b085e5c0159e9564ef5f63ee0ed6b818ade8ef04"
 
-install_linux_arm "Go Linux arm 1.16.7" "https://golang.org/dl/go1.16.7.linux-armv6l.tar.gz#b2973ceeae234866368baf9469fb7b9444857e50dc785ba879d98a0aa208a12b"
+install_linux_arm "Go Linux arm 1.16.7" "https://go.dev/dl/go1.16.7.linux-armv6l.tar.gz#b2973ceeae234866368baf9469fb7b9444857e50dc785ba879d98a0aa208a12b"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.16.7" "https://golang.org/dl/go1.16.7.linux-arm64.tar.gz#63d6b53ecbd2b05c1f0e9903c92042663f2f68afdbb67f4d0d12700156869bac"
+install_linux_arm_64bit "Go Linux arm 64bit 1.16.7" "https://go.dev/dl/go1.16.7.linux-arm64.tar.gz#63d6b53ecbd2b05c1f0e9903c92042663f2f68afdbb67f4d0d12700156869bac"

--- a/plugins/go-build/share/go-build/1.16.8
+++ b/plugins/go-build/share/go-build/1.16.8
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.16.8" "https://golang.org/dl/go1.16.8.darwin-amd64.tar.gz#516d32882e8570b2ca4e4dd1d9cf250a7e10b23f73a419085701e78599bc7a27"
+install_darwin_64bit "Go Darwin 64bit 1.16.8" "https://go.dev/dl/go1.16.8.darwin-amd64.tar.gz#516d32882e8570b2ca4e4dd1d9cf250a7e10b23f73a419085701e78599bc7a27"
 
-install_darwin_arm "Go Darwin arm 1.16.8" "https://golang.org/dl/go1.16.8.darwin-arm64.tar.gz#f6b5ae094726c0f3b5f3fa14520fe007ee057f0923a20de5e55d3db79672d5be"
+install_darwin_arm "Go Darwin arm 1.16.8" "https://go.dev/dl/go1.16.8.darwin-arm64.tar.gz#f6b5ae094726c0f3b5f3fa14520fe007ee057f0923a20de5e55d3db79672d5be"
 
-install_bsd_32bit "Go Freebsd 32bit 1.16.8" "https://golang.org/dl/go1.16.8.freebsd-386.tar.gz#c11ef3975881353a6f7c49cb29b1b9a1bc3daca73b43e005e0ab35ad89d667f5"
+install_bsd_32bit "Go Freebsd 32bit 1.16.8" "https://go.dev/dl/go1.16.8.freebsd-386.tar.gz#c11ef3975881353a6f7c49cb29b1b9a1bc3daca73b43e005e0ab35ad89d667f5"
 
-install_bsd_64bit "Go Freebsd 64bit 1.16.8" "https://golang.org/dl/go1.16.8.freebsd-amd64.tar.gz#680f687d896c7a18e1fe484865bec7b410fef94c26b4f68601dbf279563620e4"
+install_bsd_64bit "Go Freebsd 64bit 1.16.8" "https://go.dev/dl/go1.16.8.freebsd-amd64.tar.gz#680f687d896c7a18e1fe484865bec7b410fef94c26b4f68601dbf279563620e4"
 
-install_linux_32bit "Go Linux 32bit 1.16.8" "https://golang.org/dl/go1.16.8.linux-386.tar.gz#ae5efe038fdc5d9f5bcef82389af8d070c3e753dc3ba3711d9368a9d5f9c957f"
+install_linux_32bit "Go Linux 32bit 1.16.8" "https://go.dev/dl/go1.16.8.linux-386.tar.gz#ae5efe038fdc5d9f5bcef82389af8d070c3e753dc3ba3711d9368a9d5f9c957f"
 
-install_linux_64bit "Go Linux 64bit 1.16.8" "https://golang.org/dl/go1.16.8.linux-amd64.tar.gz#f32501aeb8b7b723bc7215f6c373abb6981bbc7e1c7b44e9f07317e1a300dce2"
+install_linux_64bit "Go Linux 64bit 1.16.8" "https://go.dev/dl/go1.16.8.linux-amd64.tar.gz#f32501aeb8b7b723bc7215f6c373abb6981bbc7e1c7b44e9f07317e1a300dce2"
 
-install_linux_arm "Go Linux arm 1.16.8" "https://golang.org/dl/go1.16.8.linux-armv6l.tar.gz#9c03d32e6b9622de4f4ce6e46bc1b7f8c738389ab70e1270282f488cd89079ee"
+install_linux_arm "Go Linux arm 1.16.8" "https://go.dev/dl/go1.16.8.linux-armv6l.tar.gz#9c03d32e6b9622de4f4ce6e46bc1b7f8c738389ab70e1270282f488cd89079ee"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.16.8" "https://golang.org/dl/go1.16.8.linux-arm64.tar.gz#430dbe185417204f6788913197ab3b189b6deae9c9b524f262858e53dab239c2"
+install_linux_arm_64bit "Go Linux arm 64bit 1.16.8" "https://go.dev/dl/go1.16.8.linux-arm64.tar.gz#430dbe185417204f6788913197ab3b189b6deae9c9b524f262858e53dab239c2"

--- a/plugins/go-build/share/go-build/1.16.9
+++ b/plugins/go-build/share/go-build/1.16.9
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.16.9" "https://golang.org/dl/go1.16.9.darwin-amd64.tar.gz#34c810c0ac4311714d5443c944520a543e3b647248759e81570ab294fe6071e9"
+install_darwin_64bit "Go Darwin 64bit 1.16.9" "https://go.dev/dl/go1.16.9.darwin-amd64.tar.gz#34c810c0ac4311714d5443c944520a543e3b647248759e81570ab294fe6071e9"
 
-install_darwin_arm "Go Darwin arm 1.16.9" "https://golang.org/dl/go1.16.9.darwin-arm64.tar.gz#cfbb4fa46f09671b7fe21be06232abad36cfef1673b45b92229fa15e75d347b6"
+install_darwin_arm "Go Darwin arm 1.16.9" "https://go.dev/dl/go1.16.9.darwin-arm64.tar.gz#cfbb4fa46f09671b7fe21be06232abad36cfef1673b45b92229fa15e75d347b6"
 
-install_bsd_32bit "Go Freebsd 32bit 1.16.9" "https://golang.org/dl/go1.16.9.freebsd-386.tar.gz#05b311c054c37ea861403db4924a7bf4d82fe1b7b85e49e1cbc22bf296177517"
+install_bsd_32bit "Go Freebsd 32bit 1.16.9" "https://go.dev/dl/go1.16.9.freebsd-386.tar.gz#05b311c054c37ea861403db4924a7bf4d82fe1b7b85e49e1cbc22bf296177517"
 
-install_bsd_64bit "Go Freebsd 64bit 1.16.9" "https://golang.org/dl/go1.16.9.freebsd-amd64.tar.gz#a76292499110c4df0c7730261e1b8a71c6a0b9d0d2dc414efb6e416284a1e6a6"
+install_bsd_64bit "Go Freebsd 64bit 1.16.9" "https://go.dev/dl/go1.16.9.freebsd-amd64.tar.gz#a76292499110c4df0c7730261e1b8a71c6a0b9d0d2dc414efb6e416284a1e6a6"
 
-install_linux_32bit "Go Linux 32bit 1.16.9" "https://golang.org/dl/go1.16.9.linux-386.tar.gz#dc7860acb42afda31cd170f03699e6b4249735dff8b5fb4819303fa3c7f1b05b"
+install_linux_32bit "Go Linux 32bit 1.16.9" "https://go.dev/dl/go1.16.9.linux-386.tar.gz#dc7860acb42afda31cd170f03699e6b4249735dff8b5fb4819303fa3c7f1b05b"
 
-install_linux_64bit "Go Linux 64bit 1.16.9" "https://golang.org/dl/go1.16.9.linux-amd64.tar.gz#d2c095c95f63c2a3ef961000e0ecb9d81d5c68b6ece176e2a8a2db82dc02931c"
+install_linux_64bit "Go Linux 64bit 1.16.9" "https://go.dev/dl/go1.16.9.linux-amd64.tar.gz#d2c095c95f63c2a3ef961000e0ecb9d81d5c68b6ece176e2a8a2db82dc02931c"
 
-install_linux_arm "Go Linux arm 1.16.9" "https://golang.org/dl/go1.16.9.linux-armv6l.tar.gz#e94d7c9769b9bfa75e0d1bc07212db844f15fb4a4515c686a5bf75d6d19c49d4"
+install_linux_arm "Go Linux arm 1.16.9" "https://go.dev/dl/go1.16.9.linux-armv6l.tar.gz#e94d7c9769b9bfa75e0d1bc07212db844f15fb4a4515c686a5bf75d6d19c49d4"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.16.9" "https://golang.org/dl/go1.16.9.linux-arm64.tar.gz#92b3c4051b9388181d2fedf498a4137ca5cc17550c69f96418a434f8baca3ccf"
+install_linux_arm_64bit "Go Linux arm 64bit 1.16.9" "https://go.dev/dl/go1.16.9.linux-arm64.tar.gz#92b3c4051b9388181d2fedf498a4137ca5cc17550c69f96418a434f8baca3ccf"

--- a/plugins/go-build/share/go-build/1.16beta1
+++ b/plugins/go-build/share/go-build/1.16beta1
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.16beta1" "https://golang.org/dl/go1.16beta1.darwin-amd64.tar.gz#c3518be5a17c7df746e2596e2ea310cd56348e05454f2bfbb25c5e84708dc2e2"
+install_darwin_64bit "Go Darwin 64bit 1.16beta1" "https://go.dev/dl/go1.16beta1.darwin-amd64.tar.gz#c3518be5a17c7df746e2596e2ea310cd56348e05454f2bfbb25c5e84708dc2e2"
 
-install_darwin_arm "Go Darwin arm 1.16beta1" "https://golang.org/dl/go1.16beta1.darwin-arm64.tar.gz#fd57f47987bb330fd9b438e7b4c8941b63c3807366602d99c1d99e0122ec62f1"
+install_darwin_arm "Go Darwin arm 1.16beta1" "https://go.dev/dl/go1.16beta1.darwin-arm64.tar.gz#fd57f47987bb330fd9b438e7b4c8941b63c3807366602d99c1d99e0122ec62f1"
 
-install_bsd_32bit "Go Freebsd 32bit 1.16beta1" "https://golang.org/dl/go1.16beta1.freebsd-386.tar.gz#0331c620bb09a3c7f5022bf45f14c28ceb4b043e01ecadde68a1ceff4df50f24"
+install_bsd_32bit "Go Freebsd 32bit 1.16beta1" "https://go.dev/dl/go1.16beta1.freebsd-386.tar.gz#0331c620bb09a3c7f5022bf45f14c28ceb4b043e01ecadde68a1ceff4df50f24"
 
-install_bsd_64bit "Go Freebsd 64bit 1.16beta1" "https://golang.org/dl/go1.16beta1.freebsd-amd64.tar.gz#87e72b34ae706c2269e3e665906514d11aa75856da1c99c512206e7cb3a18b74"
+install_bsd_64bit "Go Freebsd 64bit 1.16beta1" "https://go.dev/dl/go1.16beta1.freebsd-amd64.tar.gz#87e72b34ae706c2269e3e665906514d11aa75856da1c99c512206e7cb3a18b74"
 
-install_linux_32bit "Go Linux 32bit 1.16beta1" "https://golang.org/dl/go1.16beta1.linux-386.tar.gz#d32ca50affc0de30a39b63b19a19668ce539390f3d0fa71e966b726cc28ff92e"
+install_linux_32bit "Go Linux 32bit 1.16beta1" "https://go.dev/dl/go1.16beta1.linux-386.tar.gz#d32ca50affc0de30a39b63b19a19668ce539390f3d0fa71e966b726cc28ff92e"
 
-install_linux_64bit "Go Linux 64bit 1.16beta1" "https://golang.org/dl/go1.16beta1.linux-amd64.tar.gz#3931a0d493d411d6c697df6f15d5292fdd8031fde7014fded399effdad4c12d8"
+install_linux_64bit "Go Linux 64bit 1.16beta1" "https://go.dev/dl/go1.16beta1.linux-amd64.tar.gz#3931a0d493d411d6c697df6f15d5292fdd8031fde7014fded399effdad4c12d8"
 
-install_linux_arm "Go Linux arm 1.16beta1" "https://golang.org/dl/go1.16beta1.linux-armv6l.tar.gz#2f31ed765b328f79d58f78a433f6e59295b77da63153fc7582f8d8402c344999"
+install_linux_arm "Go Linux arm 1.16beta1" "https://go.dev/dl/go1.16beta1.linux-armv6l.tar.gz#2f31ed765b328f79d58f78a433f6e59295b77da63153fc7582f8d8402c344999"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.16beta1" "https://golang.org/dl/go1.16beta1.linux-arm64.tar.gz#b0f66bca136b4de8fd29645b50efa9941dc5b9eb5a67a3da837d5f8096b3431c"
+install_linux_arm_64bit "Go Linux arm 64bit 1.16beta1" "https://go.dev/dl/go1.16beta1.linux-arm64.tar.gz#b0f66bca136b4de8fd29645b50efa9941dc5b9eb5a67a3da837d5f8096b3431c"

--- a/plugins/go-build/share/go-build/1.17.0
+++ b/plugins/go-build/share/go-build/1.17.0
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.17.0" "https://golang.org/dl/go1.17.darwin-amd64.tar.gz#355bd544ce08d7d484d9d7de05a71b5c6f5bc10aa4b316688c2192aeb3dacfd1"
+install_darwin_64bit "Go Darwin 64bit 1.17.0" "https://go.dev/dl/go1.17.darwin-amd64.tar.gz#355bd544ce08d7d484d9d7de05a71b5c6f5bc10aa4b316688c2192aeb3dacfd1"
 
-install_darwin_arm "Go Darwin arm 1.17.0" "https://golang.org/dl/go1.17.darwin-arm64.tar.gz#da4e3e3c194bf9eed081de8842a157120ef44a7a8d7c820201adae7b0e28b20b"
+install_darwin_arm "Go Darwin arm 1.17.0" "https://go.dev/dl/go1.17.darwin-arm64.tar.gz#da4e3e3c194bf9eed081de8842a157120ef44a7a8d7c820201adae7b0e28b20b"
 
-install_bsd_32bit "Go Freebsd 32bit 1.17.0" "https://golang.org/dl/go1.17.freebsd-386.tar.gz#6819a7a11b8351d5d5768f2fff666abde97577602394f132cb7f85b3a7151f05"
+install_bsd_32bit "Go Freebsd 32bit 1.17.0" "https://go.dev/dl/go1.17.freebsd-386.tar.gz#6819a7a11b8351d5d5768f2fff666abde97577602394f132cb7f85b3a7151f05"
 
-install_bsd_64bit "Go Freebsd 64bit 1.17.0" "https://golang.org/dl/go1.17.freebsd-amd64.tar.gz#15c184c83d99441d719da201b26256455eee85a808747c404b4183e9aa6c64b4"
+install_bsd_64bit "Go Freebsd 64bit 1.17.0" "https://go.dev/dl/go1.17.freebsd-amd64.tar.gz#15c184c83d99441d719da201b26256455eee85a808747c404b4183e9aa6c64b4"
 
-install_linux_32bit "Go Linux 32bit 1.17.0" "https://golang.org/dl/go1.17.linux-386.tar.gz#c19e3227a6ac6329db91d1af77bbf239ccd760a259c16e6b9c932d527ff14848"
+install_linux_32bit "Go Linux 32bit 1.17.0" "https://go.dev/dl/go1.17.linux-386.tar.gz#c19e3227a6ac6329db91d1af77bbf239ccd760a259c16e6b9c932d527ff14848"
 
-install_linux_64bit "Go Linux 64bit 1.17.0" "https://golang.org/dl/go1.17.linux-amd64.tar.gz#6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d"
+install_linux_64bit "Go Linux 64bit 1.17.0" "https://go.dev/dl/go1.17.linux-amd64.tar.gz#6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d"
 
-install_linux_arm "Go Linux arm 1.17.0" "https://golang.org/dl/go1.17.linux-armv6l.tar.gz#ae89d33f4e4acc222bdb04331933d5ece4ae71039812f6ccd7493cb3e8ddfb4e"
+install_linux_arm "Go Linux arm 1.17.0" "https://go.dev/dl/go1.17.linux-armv6l.tar.gz#ae89d33f4e4acc222bdb04331933d5ece4ae71039812f6ccd7493cb3e8ddfb4e"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.17.0" "https://golang.org/dl/go1.17.linux-arm64.tar.gz#01a9af009ada22122d3fcb9816049c1d21842524b38ef5d5a0e2ee4b26d7c3e7"
+install_linux_arm_64bit "Go Linux arm 64bit 1.17.0" "https://go.dev/dl/go1.17.linux-arm64.tar.gz#01a9af009ada22122d3fcb9816049c1d21842524b38ef5d5a0e2ee4b26d7c3e7"

--- a/plugins/go-build/share/go-build/1.17.1
+++ b/plugins/go-build/share/go-build/1.17.1
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.17.1" "https://golang.org/dl/go1.17.1.darwin-amd64.tar.gz#3c452046b1dfa27b70d3217c9fe6de266f9fd74d83aad81382fead70efcdffca"
+install_darwin_64bit "Go Darwin 64bit 1.17.1" "https://go.dev/dl/go1.17.1.darwin-amd64.tar.gz#3c452046b1dfa27b70d3217c9fe6de266f9fd74d83aad81382fead70efcdffca"
 
-install_darwin_arm "Go Darwin arm 1.17.1" "https://golang.org/dl/go1.17.1.darwin-arm64.tar.gz#48f48a3cfe49b7bb448510ec9bf1682439e4e95fa6888580914a3115fe853d8c"
+install_darwin_arm "Go Darwin arm 1.17.1" "https://go.dev/dl/go1.17.1.darwin-arm64.tar.gz#48f48a3cfe49b7bb448510ec9bf1682439e4e95fa6888580914a3115fe853d8c"
 
-install_bsd_32bit "Go Freebsd 32bit 1.17.1" "https://golang.org/dl/go1.17.1.freebsd-386.tar.gz#e945a5cfb2d4acd434d606175c69202a7d28660630839ade9907facec702870f"
+install_bsd_32bit "Go Freebsd 32bit 1.17.1" "https://go.dev/dl/go1.17.1.freebsd-386.tar.gz#e945a5cfb2d4acd434d606175c69202a7d28660630839ade9907facec702870f"
 
-install_bsd_64bit "Go Freebsd 64bit 1.17.1" "https://golang.org/dl/go1.17.1.freebsd-amd64.tar.gz#cfa16e98602a88fc80aca045a271e45b76fc30a6bd472c67329ebd362dd984d0"
+install_bsd_64bit "Go Freebsd 64bit 1.17.1" "https://go.dev/dl/go1.17.1.freebsd-amd64.tar.gz#cfa16e98602a88fc80aca045a271e45b76fc30a6bd472c67329ebd362dd984d0"
 
-install_linux_32bit "Go Linux 32bit 1.17.1" "https://golang.org/dl/go1.17.1.linux-386.tar.gz#e60bb44046f424ba2cc47db7b183079b5add2f8cfa6887daf45bf2f317cc2f53"
+install_linux_32bit "Go Linux 32bit 1.17.1" "https://go.dev/dl/go1.17.1.linux-386.tar.gz#e60bb44046f424ba2cc47db7b183079b5add2f8cfa6887daf45bf2f317cc2f53"
 
-install_linux_64bit "Go Linux 64bit 1.17.1" "https://golang.org/dl/go1.17.1.linux-amd64.tar.gz#dab7d9c34361dc21ec237d584590d72500652e7c909bf082758fb63064fca0ef"
+install_linux_64bit "Go Linux 64bit 1.17.1" "https://go.dev/dl/go1.17.1.linux-amd64.tar.gz#dab7d9c34361dc21ec237d584590d72500652e7c909bf082758fb63064fca0ef"
 
-install_linux_arm "Go Linux arm 1.17.1" "https://golang.org/dl/go1.17.1.linux-armv6l.tar.gz#ed3e4dbc9b80353f6482c441d65b51808290e94ff1d15d56da5f4a7be7353758"
+install_linux_arm "Go Linux arm 1.17.1" "https://go.dev/dl/go1.17.1.linux-armv6l.tar.gz#ed3e4dbc9b80353f6482c441d65b51808290e94ff1d15d56da5f4a7be7353758"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.17.1" "https://golang.org/dl/go1.17.1.linux-arm64.tar.gz#53b29236fa03ed862670a5e5e2ab2439a2dc288fe61544aa392062104ac0128c"
+install_linux_arm_64bit "Go Linux arm 64bit 1.17.1" "https://go.dev/dl/go1.17.1.linux-arm64.tar.gz#53b29236fa03ed862670a5e5e2ab2439a2dc288fe61544aa392062104ac0128c"

--- a/plugins/go-build/share/go-build/1.17.2
+++ b/plugins/go-build/share/go-build/1.17.2
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.17.2" "https://golang.org/dl/go1.17.2.darwin-amd64.tar.gz#7914497a302a132a465d33f5ee044ce05568bacdb390ab805cb75a3435a23f94"
+install_darwin_64bit "Go Darwin 64bit 1.17.2" "https://go.dev/dl/go1.17.2.darwin-amd64.tar.gz#7914497a302a132a465d33f5ee044ce05568bacdb390ab805cb75a3435a23f94"
 
-install_darwin_arm "Go Darwin arm 1.17.2" "https://golang.org/dl/go1.17.2.darwin-arm64.tar.gz#ce8771bd3edfb5b28104084b56bbb532eeb47fbb7769c3e664c6223712c30904"
+install_darwin_arm "Go Darwin arm 1.17.2" "https://go.dev/dl/go1.17.2.darwin-arm64.tar.gz#ce8771bd3edfb5b28104084b56bbb532eeb47fbb7769c3e664c6223712c30904"
 
-install_bsd_32bit "Go Freebsd 32bit 1.17.2" "https://golang.org/dl/go1.17.2.freebsd-386.tar.gz#8cea5b8d1f8e8cbb58069bfed58954c71c5b1aca2f3c857765dae83bf724d0d7"
+install_bsd_32bit "Go Freebsd 32bit 1.17.2" "https://go.dev/dl/go1.17.2.freebsd-386.tar.gz#8cea5b8d1f8e8cbb58069bfed58954c71c5b1aca2f3c857765dae83bf724d0d7"
 
-install_bsd_64bit "Go Freebsd 64bit 1.17.2" "https://golang.org/dl/go1.17.2.freebsd-amd64.tar.gz#c96e57218fb03e74d683ad63b1684d44c89d5e5b994f36102b33dce21b58499a"
+install_bsd_64bit "Go Freebsd 64bit 1.17.2" "https://go.dev/dl/go1.17.2.freebsd-amd64.tar.gz#c96e57218fb03e74d683ad63b1684d44c89d5e5b994f36102b33dce21b58499a"
 
-install_linux_32bit "Go Linux 32bit 1.17.2" "https://golang.org/dl/go1.17.2.linux-386.tar.gz#8617f2e40d51076983502894181ae639d1d8101bfbc4d7463a2b442f239f5596"
+install_linux_32bit "Go Linux 32bit 1.17.2" "https://go.dev/dl/go1.17.2.linux-386.tar.gz#8617f2e40d51076983502894181ae639d1d8101bfbc4d7463a2b442f239f5596"
 
-install_linux_64bit "Go Linux 64bit 1.17.2" "https://golang.org/dl/go1.17.2.linux-amd64.tar.gz#f242a9db6a0ad1846de7b6d94d507915d14062660616a61ef7c808a76e4f1676"
+install_linux_64bit "Go Linux 64bit 1.17.2" "https://go.dev/dl/go1.17.2.linux-amd64.tar.gz#f242a9db6a0ad1846de7b6d94d507915d14062660616a61ef7c808a76e4f1676"
 
-install_linux_arm "Go Linux arm 1.17.2" "https://golang.org/dl/go1.17.2.linux-armv6l.tar.gz#04d16105008230a9763005be05606f7eb1c683a3dbf0fbfed4034b23889cb7f2"
+install_linux_arm "Go Linux arm 1.17.2" "https://go.dev/dl/go1.17.2.linux-armv6l.tar.gz#04d16105008230a9763005be05606f7eb1c683a3dbf0fbfed4034b23889cb7f2"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.17.2" "https://golang.org/dl/go1.17.2.linux-arm64.tar.gz#a5a43c9cdabdb9f371d56951b14290eba8ce2f9b0db48fb5fc657943984fd4fc"
+install_linux_arm_64bit "Go Linux arm 64bit 1.17.2" "https://go.dev/dl/go1.17.2.linux-arm64.tar.gz#a5a43c9cdabdb9f371d56951b14290eba8ce2f9b0db48fb5fc657943984fd4fc"

--- a/plugins/go-build/share/go-build/1.17.3
+++ b/plugins/go-build/share/go-build/1.17.3
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.17.3" "https://golang.org/dl/go1.17.3.darwin-amd64.tar.gz#765c021e372a87ce0bc58d3670ab143008dae9305a79e9fa83440425529bb636"
+install_darwin_64bit "Go Darwin 64bit 1.17.3" "https://go.dev/dl/go1.17.3.darwin-amd64.tar.gz#765c021e372a87ce0bc58d3670ab143008dae9305a79e9fa83440425529bb636"
 
-install_darwin_arm "Go Darwin arm 1.17.3" "https://golang.org/dl/go1.17.3.darwin-arm64.tar.gz#ffe45ef267271b9681ca96ca9b0eb9b8598dd82f7bb95b27af3eef2461dc3d2c"
+install_darwin_arm "Go Darwin arm 1.17.3" "https://go.dev/dl/go1.17.3.darwin-arm64.tar.gz#ffe45ef267271b9681ca96ca9b0eb9b8598dd82f7bb95b27af3eef2461dc3d2c"
 
-install_bsd_32bit "Go Freebsd 32bit 1.17.3" "https://golang.org/dl/go1.17.3.freebsd-386.tar.gz#f1359b53f99364e2907e0b0ee4a4f22dc53a8e26a2caa3bec86d6499b78f83eb"
+install_bsd_32bit "Go Freebsd 32bit 1.17.3" "https://go.dev/dl/go1.17.3.freebsd-386.tar.gz#f1359b53f99364e2907e0b0ee4a4f22dc53a8e26a2caa3bec86d6499b78f83eb"
 
-install_bsd_64bit "Go Freebsd 64bit 1.17.3" "https://golang.org/dl/go1.17.3.freebsd-amd64.tar.gz#bfb6fb7752bfb2f88d7c0a0b4e4a950f88882bb22c24e2fd8b9018c2b1b167a1"
+install_bsd_64bit "Go Freebsd 64bit 1.17.3" "https://go.dev/dl/go1.17.3.freebsd-amd64.tar.gz#bfb6fb7752bfb2f88d7c0a0b4e4a950f88882bb22c24e2fd8b9018c2b1b167a1"
 
-install_linux_32bit "Go Linux 32bit 1.17.3" "https://golang.org/dl/go1.17.3.linux-386.tar.gz#982487a0264626950c635c5e185df68ecaadcca1361956207578d661a7b03bee"
+install_linux_32bit "Go Linux 32bit 1.17.3" "https://go.dev/dl/go1.17.3.linux-386.tar.gz#982487a0264626950c635c5e185df68ecaadcca1361956207578d661a7b03bee"
 
-install_linux_64bit "Go Linux 64bit 1.17.3" "https://golang.org/dl/go1.17.3.linux-amd64.tar.gz#550f9845451c0c94be679faf116291e7807a8d78b43149f9506c1b15eb89008c"
+install_linux_64bit "Go Linux 64bit 1.17.3" "https://go.dev/dl/go1.17.3.linux-amd64.tar.gz#550f9845451c0c94be679faf116291e7807a8d78b43149f9506c1b15eb89008c"
 
-install_linux_arm "Go Linux arm 1.17.3" "https://golang.org/dl/go1.17.3.linux-armv6l.tar.gz#aa0d5516c8bd61654990916274d27491cfa229d322475502b247a8dc885adec5"
+install_linux_arm "Go Linux arm 1.17.3" "https://go.dev/dl/go1.17.3.linux-armv6l.tar.gz#aa0d5516c8bd61654990916274d27491cfa229d322475502b247a8dc885adec5"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.17.3" "https://golang.org/dl/go1.17.3.linux-arm64.tar.gz#06f505c8d27203f78706ad04e47050b49092f1b06dc9ac4fbee4f0e4d015c8d4"
+install_linux_arm_64bit "Go Linux arm 64bit 1.17.3" "https://go.dev/dl/go1.17.3.linux-arm64.tar.gz#06f505c8d27203f78706ad04e47050b49092f1b06dc9ac4fbee4f0e4d015c8d4"

--- a/plugins/go-build/share/go-build/1.17beta1
+++ b/plugins/go-build/share/go-build/1.17beta1
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.17beta1" "https://golang.org/dl/go1.17beta1.darwin-amd64.tar.gz#50046983ccd66180d1b6fbf39b4e5acb61dd08f1b53803661d86b60ba304bf80"
+install_darwin_64bit "Go Darwin 64bit 1.17beta1" "https://go.dev/dl/go1.17beta1.darwin-amd64.tar.gz#50046983ccd66180d1b6fbf39b4e5acb61dd08f1b53803661d86b60ba304bf80"
 
-install_darwin_arm "Go Darwin arm 1.17beta1" "https://golang.org/dl/go1.17beta1.darwin-arm64.tar.gz#14f477d7c8d6ced879318257a57fc5f39e23aa4502a0f595c0103039e0a4abc0"
+install_darwin_arm "Go Darwin arm 1.17beta1" "https://go.dev/dl/go1.17beta1.darwin-arm64.tar.gz#14f477d7c8d6ced879318257a57fc5f39e23aa4502a0f595c0103039e0a4abc0"
 
-install_bsd_32bit "Go Freebsd 32bit 1.17beta1" "https://golang.org/dl/go1.17beta1.freebsd-386.tar.gz#d3ea61c33445c6f9cfa5543b199badf6a9953cfb8fa825986fd6f2cba4355e63"
+install_bsd_32bit "Go Freebsd 32bit 1.17beta1" "https://go.dev/dl/go1.17beta1.freebsd-386.tar.gz#d3ea61c33445c6f9cfa5543b199badf6a9953cfb8fa825986fd6f2cba4355e63"
 
-install_bsd_64bit "Go Freebsd 64bit 1.17beta1" "https://golang.org/dl/go1.17beta1.freebsd-amd64.tar.gz#7673f5b0478ac7cac0bfa97ad8757fdba1c3630378c5b667a6013b339c7d08aa"
+install_bsd_64bit "Go Freebsd 64bit 1.17beta1" "https://go.dev/dl/go1.17beta1.freebsd-amd64.tar.gz#7673f5b0478ac7cac0bfa97ad8757fdba1c3630378c5b667a6013b339c7d08aa"
 
-install_linux_32bit "Go Linux 32bit 1.17beta1" "https://golang.org/dl/go1.17beta1.linux-386.tar.gz#cebbf75985ba7e6f1a5b137916a6019685d52ecf36c262092ffc3f714cd85974"
+install_linux_32bit "Go Linux 32bit 1.17beta1" "https://go.dev/dl/go1.17beta1.linux-386.tar.gz#cebbf75985ba7e6f1a5b137916a6019685d52ecf36c262092ffc3f714cd85974"
 
-install_linux_64bit "Go Linux 64bit 1.17beta1" "https://golang.org/dl/go1.17beta1.linux-amd64.tar.gz#a479681705b65971f9db079bfce53c4393bfa241d952eb09de88fb40677d3c4c"
+install_linux_64bit "Go Linux 64bit 1.17beta1" "https://go.dev/dl/go1.17beta1.linux-amd64.tar.gz#a479681705b65971f9db079bfce53c4393bfa241d952eb09de88fb40677d3c4c"
 
-install_linux_arm "Go Linux arm 1.17beta1" "https://golang.org/dl/go1.17beta1.linux-armv6l.tar.gz#f4ab69c75a1f9e43b07ca9a0bfdf68ca1e2b0b51d4ebfb8c79f60ed14629f4e6"
+install_linux_arm "Go Linux arm 1.17beta1" "https://go.dev/dl/go1.17beta1.linux-armv6l.tar.gz#f4ab69c75a1f9e43b07ca9a0bfdf68ca1e2b0b51d4ebfb8c79f60ed14629f4e6"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.17beta1" "https://golang.org/dl/go1.17beta1.linux-arm64.tar.gz#ede56f79c5061146929ab4a128e8ee7bc713d141e87b3df4e0aa670938e128b3"
+install_linux_arm_64bit "Go Linux arm 64bit 1.17beta1" "https://go.dev/dl/go1.17beta1.linux-arm64.tar.gz#ede56f79c5061146929ab4a128e8ee7bc713d141e87b3df4e0aa670938e128b3"

--- a/plugins/go-build/share/go-build/1.17rc1
+++ b/plugins/go-build/share/go-build/1.17rc1
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.17rc1" "https://golang.org/dl/go1.17rc1.darwin-amd64.tar.gz#bc9971349a154e8c96e9488ea8f60f8d859725275a11562e38f4a7314df52200"
+install_darwin_64bit "Go Darwin 64bit 1.17rc1" "https://go.dev/dl/go1.17rc1.darwin-amd64.tar.gz#bc9971349a154e8c96e9488ea8f60f8d859725275a11562e38f4a7314df52200"
 
-install_darwin_arm "Go Darwin arm 1.17rc1" "https://golang.org/dl/go1.17rc1.darwin-arm64.tar.gz#39dcd3fe8443bfa42f17defaf5bc95944657e9a30f79c695d17e6738012110ff"
+install_darwin_arm "Go Darwin arm 1.17rc1" "https://go.dev/dl/go1.17rc1.darwin-arm64.tar.gz#39dcd3fe8443bfa42f17defaf5bc95944657e9a30f79c695d17e6738012110ff"
 
-install_bsd_32bit "Go Freebsd 32bit 1.17rc1" "https://golang.org/dl/go1.17rc1.freebsd-386.tar.gz#0e0ffff26c63f8cc9ffcf8ae9417c569e4c14b82b0e10abb6a3a422e5b191889"
+install_bsd_32bit "Go Freebsd 32bit 1.17rc1" "https://go.dev/dl/go1.17rc1.freebsd-386.tar.gz#0e0ffff26c63f8cc9ffcf8ae9417c569e4c14b82b0e10abb6a3a422e5b191889"
 
-install_bsd_64bit "Go Freebsd 64bit 1.17rc1" "https://golang.org/dl/go1.17rc1.freebsd-amd64.tar.gz#d241d523f22744a244a19539d2c724130af6bed23e1ba034a4e8f0624af0f9b3"
+install_bsd_64bit "Go Freebsd 64bit 1.17rc1" "https://go.dev/dl/go1.17rc1.freebsd-amd64.tar.gz#d241d523f22744a244a19539d2c724130af6bed23e1ba034a4e8f0624af0f9b3"
 
-install_linux_32bit "Go Linux 32bit 1.17rc1" "https://golang.org/dl/go1.17rc1.linux-386.tar.gz#e9b78a4bd98165b86bb887643f58cc0464cc7ff7fae12516fc43114809c71e07"
+install_linux_32bit "Go Linux 32bit 1.17rc1" "https://go.dev/dl/go1.17rc1.linux-386.tar.gz#e9b78a4bd98165b86bb887643f58cc0464cc7ff7fae12516fc43114809c71e07"
 
-install_linux_64bit "Go Linux 64bit 1.17rc1" "https://golang.org/dl/go1.17rc1.linux-amd64.tar.gz#bfbd3881a01ca3826777b1c40f241acacd45b14730d373259cd673d74e15e534"
+install_linux_64bit "Go Linux 64bit 1.17rc1" "https://go.dev/dl/go1.17rc1.linux-amd64.tar.gz#bfbd3881a01ca3826777b1c40f241acacd45b14730d373259cd673d74e15e534"
 
-install_linux_arm "Go Linux arm 1.17rc1" "https://golang.org/dl/go1.17rc1.linux-armv6l.tar.gz#1fd5c3733d6fab5ebcb3ca6ae2b478d370bb0638ba3966284ed7e7aa97acfc8a"
+install_linux_arm "Go Linux arm 1.17rc1" "https://go.dev/dl/go1.17rc1.linux-armv6l.tar.gz#1fd5c3733d6fab5ebcb3ca6ae2b478d370bb0638ba3966284ed7e7aa97acfc8a"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.17rc1" "https://golang.org/dl/go1.17rc1.linux-arm64.tar.gz#7498e426ce814a94a1d271d6bb80b9a2cf8c77ec49df531c57bd7a9ff82cfa4e"
+install_linux_arm_64bit "Go Linux arm 64bit 1.17rc1" "https://go.dev/dl/go1.17rc1.linux-arm64.tar.gz#7498e426ce814a94a1d271d6bb80b9a2cf8c77ec49df531c57bd7a9ff82cfa4e"

--- a/plugins/go-build/share/go-build/1.17rc2
+++ b/plugins/go-build/share/go-build/1.17rc2
@@ -1,15 +1,15 @@
-install_darwin_64bit "Go Darwin 64bit 1.17rc2" "https://golang.org/dl/go1.17rc2.darwin-amd64.tar.gz#8abf0b17d6a0664e53ea7e1aecb649e2378732d2d97e8a292c27e6aae711c6c9"
+install_darwin_64bit "Go Darwin 64bit 1.17rc2" "https://go.dev/dl/go1.17rc2.darwin-amd64.tar.gz#8abf0b17d6a0664e53ea7e1aecb649e2378732d2d97e8a292c27e6aae711c6c9"
 
-install_darwin_arm "Go Darwin arm 1.17rc2" "https://golang.org/dl/go1.17rc2.darwin-arm64.tar.gz#fb8954dc8172bfabb8c22125a994a04278be554f15a1cb26ff2595841d9c1ba1"
+install_darwin_arm "Go Darwin arm 1.17rc2" "https://go.dev/dl/go1.17rc2.darwin-arm64.tar.gz#fb8954dc8172bfabb8c22125a994a04278be554f15a1cb26ff2595841d9c1ba1"
 
-install_bsd_32bit "Go Freebsd 32bit 1.17rc2" "https://golang.org/dl/go1.17rc2.freebsd-386.tar.gz#cffffb5dc4937d1f6728cc9a88aa33ade059040a3b3856eca8e65d31df3e3b49"
+install_bsd_32bit "Go Freebsd 32bit 1.17rc2" "https://go.dev/dl/go1.17rc2.freebsd-386.tar.gz#cffffb5dc4937d1f6728cc9a88aa33ade059040a3b3856eca8e65d31df3e3b49"
 
-install_bsd_64bit "Go Freebsd 64bit 1.17rc2" "https://golang.org/dl/go1.17rc2.freebsd-amd64.tar.gz#48b36ed9618b81d4d59acdec3bcf56f18e97173c46dd5efa875ad7b03da61330"
+install_bsd_64bit "Go Freebsd 64bit 1.17rc2" "https://go.dev/dl/go1.17rc2.freebsd-amd64.tar.gz#48b36ed9618b81d4d59acdec3bcf56f18e97173c46dd5efa875ad7b03da61330"
 
-install_linux_32bit "Go Linux 32bit 1.17rc2" "https://golang.org/dl/go1.17rc2.linux-386.tar.gz#273fd4647d2311e3044d3d937eedbee91477317d867b6c81636fdc0a9ba7f947"
+install_linux_32bit "Go Linux 32bit 1.17rc2" "https://go.dev/dl/go1.17rc2.linux-386.tar.gz#273fd4647d2311e3044d3d937eedbee91477317d867b6c81636fdc0a9ba7f947"
 
-install_linux_64bit "Go Linux 64bit 1.17rc2" "https://golang.org/dl/go1.17rc2.linux-amd64.tar.gz#328235edc7c7d2a51d6c6cb4d7ff97e97357654ef9e1098b9a4603a9d278ad04"
+install_linux_64bit "Go Linux 64bit 1.17rc2" "https://go.dev/dl/go1.17rc2.linux-amd64.tar.gz#328235edc7c7d2a51d6c6cb4d7ff97e97357654ef9e1098b9a4603a9d278ad04"
 
-install_linux_arm "Go Linux arm 1.17rc2" "https://golang.org/dl/go1.17rc2.linux-armv6l.tar.gz#4820fcd80b47e7d7dc1f15343c4fb59e66183cef9dadb3d3ac10f82615ad2141"
+install_linux_arm "Go Linux arm 1.17rc2" "https://go.dev/dl/go1.17rc2.linux-armv6l.tar.gz#4820fcd80b47e7d7dc1f15343c4fb59e66183cef9dadb3d3ac10f82615ad2141"
 
-install_linux_arm_64bit "Go Linux arm 64bit 1.17rc2" "https://golang.org/dl/go1.17rc2.linux-arm64.tar.gz#4e1b335c53bf28cd20c5f7f2f7e79187b93e71c1d027448e313097785efb673d"
+install_linux_arm_64bit "Go Linux arm 64bit 1.17rc2" "https://go.dev/dl/go1.17rc2.linux-arm64.tar.gz#4e1b335c53bf28cd20c5f7f2f7e79187b93e71c1d027448e313097785efb673d"


### PR DESCRIPTION
# Description

Address [Issue #202](https://github.com/syndbg/goenv/issues/202)

# Summary

- Replace `golang.org` with `go.dev`.
- Replace `www.golang.org` with `go.dev`.

# Notes

- The URLs in version file were replaced by the following steps on my Mac.

  ```
  $ find ./ -type f | xargs sed -i '' 's/golang.org/go.dev/g'
  $ git diff --name-only
  plugins/go-build/share/go-build/1.13.13
  plugins/go-build/share/go-build/1.13.14
  <snip>
  plugins/go-build/share/go-build/1.17beta1
  plugins/go-build/share/go-build/1.17rc1
  ```
