### PR TITLE
Go 1.18.3 Fix tar.gz MacOS checksum

### DIFF
--- a/plugins/go-build/share/go-build/1.18.3
+++ b/plugins/go-build/share/go-build/1.18.3
@@ -1,4 +1,4 @@
-install_darwin_64bit "Go Darwin 64bit 1.18.3" "https://golang.org/dl/go1.18.3.darwin-amd64.tar.gz#a23a24c5528671d444328a36a98056902f699a5a211b6ad5db29ca0c012e0085"
+install_darwin_64bit "Go Darwin 64bit 1.18.3" "https://golang.org/dl/go1.18.3.darwin-amd64.tar.gz#d9dcf8fc35da54c6f259be41954783a9f4984945a855d03a003a7fd6ea4c5ca1"
 
 install_darwin_arm "Go Darwin arm 1.18.3" "https://golang.org/dl/go1.18.3.darwin-arm64.tar.gz#40ecd383c941cc9f0682e6a6f2a333539d58c7dea15c842434d03afafe2f7242"
 


### PR DESCRIPTION
Checksum Mismatch Fix (Resolves #230):

The .pkg checksum was referenced instead of the .tar.gz. All other checksums were verified and correct per the [Downloads Page](https://go.dev/dl#go1.18.3)

<img width="828" alt="image" src="https://user-images.githubusercontent.com/28963807/172393976-b6007be8-9e48-496f-9177-cd7e51c05de5.png">
