### PR TITLE
Scheduled Checks for new Go Definitions via GitHub Actions

### DIFF
--- a/.github/workflows/go_versions.yml
+++ b/.github/workflows/go_versions.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: master
       - name: Install JQ
         run: sudo apt install jq
       - name: Remove golang

--- a/.github/workflows/go_versions.yml
+++ b/.github/workflows/go_versions.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 8 * * *" # every day at 8AM UTC
 jobs:
@@ -11,7 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           ref: master
+          token: ${{ secrets.GH_TOKEN }}
       - name: Install JQ
         run: sudo apt install jq
       - name: Remove golang

--- a/.github/workflows/go_versions.yml
+++ b/.github/workflows/go_versions.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Check latest version of Go against Goenv
         run: ./scripts/latest_version.sh
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/go_versions.yml
+++ b/.github/workflows/go_versions.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   schedule:
-    - cron: "0 0 * * *" # every day at midnight
+    - cron: "0 8 * * *" # every day at 8AM UTC
 jobs:
   build:
     strategy:

--- a/.github/workflows/go_versions.yml
+++ b/.github/workflows/go_versions.yml
@@ -1,7 +1,7 @@
 name: CI
-# on:
-#   schedule:
-#     - cron: "0 0 * * *" # every day at midnight
+on:
+  schedule:
+    - cron: "0 0 * * *" # every day at midnight
 jobs:
   build:
     strategy:
@@ -18,3 +18,5 @@ jobs:
         run: export PATH="$PATH:./bin/goenv"
       - name: Check latest version of Go against Goenv
         run: ./scripts/latest_version.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go_versions.yml
+++ b/.github/workflows/go_versions.yml
@@ -17,7 +17,4 @@ jobs:
       - name: Add goenv to PATH
         run: export PATH="$PATH:./bin/goenv"
       - name: Check latest version of Go against Goenv
-        run: |
-          . ./scripts/latest_version.sh
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4.2.0
+        run: ./scripts/latest_version.sh

--- a/.github/workflows/go_versions.yml
+++ b/.github/workflows/go_versions.yml
@@ -1,0 +1,23 @@
+name: CI
+# on:
+#   schedule:
+#     - cron: "0 0 * * *" # every day at midnight
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install JQ
+        run: sudo apt install jq
+      - name: Remove golang
+        run: sudo rm -rf $(which go)
+      - name: Add goenv to PATH
+        run: export PATH="$PATH:./bin/goenv"
+      - name: Check latest version of Go against Goenv
+        run: |
+          . ./scripts/latest_version.sh
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4.2.0

--- a/plugins/go-build/bin/goenv-install
+++ b/plugins/go-build/bin/goenv-install
@@ -63,11 +63,11 @@ definitions() {
 }
 
 latest_version() {
-  definitions | grep -oE "^$1\\.([0-9]+)?" | tail -1
+  definitions | grep -oE "^$1\\.([0-9]+)?$" | tail -1
 }
 
 latest_includes_unstable_version() {
-  definitions | grep -ioE "^$1\\.?([0-9]+|beta[0-9]+|rc[0-9]+)?" | tail -1
+  definitions | grep -ioE "^$1\\.?([0-9]+|beta[0-9]+|rc[0-9]+)?$" | tail -1
 }
 
 indent() {

--- a/scripts/latest_version.sh
+++ b/scripts/latest_version.sh
@@ -123,3 +123,6 @@ echo 'All done!'
 
 # All done, reset PATH
 PATH=$OLD_PATH
+
+export CREATED_BRANCH_NAME=$BRANCH_NAME
+export NEW_VERSION=true

--- a/scripts/latest_version.sh
+++ b/scripts/latest_version.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+GO_BUILD_DIR=$GIT_ROOT/plugins/go-build
+
+OLD_PATH=$PATH
+
+PATH="$PATH:$GIT_ROOT/plugins/go-build/bin"
+
+# Load shared library functions
+eval "$(go-build --lib)"
+
+definitions() {
+    local query="$1"
+    go-build --definitions | $(type -p ggrep grep | head -1) -F "$query" || true
+}
+
+latest_includes_unstable_version() {
+    definitions | grep -ioE "^$1\\.?([0-9]+|beta[0-9]+|rc[0-9]+)?$" | tail -1
+}
+
+printf "fetching latest goenv definition..."
+
+LATEST_GOENV_DEFINITION=$(latest_includes_unstable_version "[0-9]\\.[0-9]+")
+
+printf " %s\n" $LATEST_GOENV_DEFINITION
+
+printf "fetching latest go version..."
+
+LATEST_GO_DEFINITIONS=$(curl -s "https://go.dev/dl/?mode=json&include=all" | jq '.[0]')
+LATEST_GO_VERSION=$(echo $LATEST_GO_DEFINITIONS | jq '.version' | sed -e 's/go//' -e 's/\"//g')
+
+printf " %s\n" $LATEST_GO_VERSION
+
+if [[ $LATEST_GO_VERSION == $LATEST_GOENV_DEFINITION ]]; then
+    echo "latest goenv definition ($LATEST_GOENV_DEFINITION) matches latest Go version ($LATEST_GO_VERSION)"
+    export NEW_VERSION=false
+    exit 0
+fi
+
+BRANCH_NAME="add_$LATEST_GO_VERSION"
+
+EXISTS=$(git branch -r -l 'origin*' | sed -E -e 's/^[^\/]+\///g' -e 's/HEAD.+//' | grep "$BRANCH_NAME")
+
+if [[ -n $EXISTS ]]; then
+    echo "A PR already exists on branch $BRANCH_NAME for the latest Go version ($LATEST_GO_VERSION)"
+    export NEW_VERSION=false
+    exit 0
+fi
+
+echo "checking out new Git branch $BRANCH_NAME..."
+
+git checkout -b $BRANCH_NAME
+
+printf "Creating new definitions for $LATEST_GO_VERSION..."
+
+capitalize() {
+    printf '%s' "$1" | head -c 1 | tr [:lower:] [:upper:]
+    printf '%s' "$1" | tail -c '+2'
+}
+
+GO_BUILD_DEFINITION_FILE=$GO_BUILD_DIR/share/go-build/$LATEST_GO_VERSION
+
+LATEST_FILE_LIST=$(echo $LATEST_GO_DEFINITIONS | jq -c '.files[] | select(.os == "darwin" or .os == "linux" or .os == "freebsd") | select(.arch == "386" or .arch == "amd64" or .arch == "armv6l" or .arch == "arm64") | select(.kind == "archive")')
+
+echo $LATEST_FILE_LIST | jq -c '.' | while read FILE_DATA; do
+    FILENAME=$(echo $FILE_DATA | jq -r '.filename')
+    SHA256=$(echo $FILE_DATA | jq -r '.sha256')
+    OS=$(echo $FILE_DATA | jq -r '.os')
+    OS_TITLE_CASE=$(capitalize $OS)
+    ARCH=$(echo $FILE_DATA | jq -r '.arch')
+
+    case $OS in
+    darwin) ;;
+    linux) ;;
+    freebsd)
+        OS="bsd"
+        ;;
+    *)
+        echo "$OS is not valid"
+        ;;
+    esac
+
+    case $ARCH in
+    386)
+        ARCH="32bit"
+        ;;
+    amd64)
+        ARCH="64bit"
+        ;;
+    arm64)
+        if [[ $OS == "linux" ]]; then
+            ARCH="arm_64bit"
+        else
+            ARCH="arm"
+        fi
+        ;;
+    armv6l)
+        ARCH="arm"
+        ;;
+    *)
+        echo "$ARCH is not valid"
+        exit 1
+        ;;
+    esac
+
+    # Version file pattern
+    # install_{OS}_{ARCH} "Go {OS_TITLE_CASE} {ARCH} {VERSION}" "{FILENAME}#{FILE_SHA256}"
+    printf 'install_%s_%s "Go %s %s %s" "%s#%s"\n\n' $OS $ARCH $OS_TITLE_CASE "$(echo $ARCH | sed -e 's/_/ /')" $LATEST_GO_VERSION $FILENAME $SHA256 >>$GO_BUILD_DEFINITION_FILE
+done
+
+printf " done\n"
+
+echo "Committing changes..."
+
+git commit -am "[goenv-bot]: Add $LATEST_GO_VERSION definition to goenv"
+
+echo "Pushing to origin..."
+
+git push -u origin $BRANCH_NAME
+
+echo 'All done!'
+
+# All done, reset PATH
+PATH=$OLD_PATH

--- a/scripts/latest_version.sh
+++ b/scripts/latest_version.sh
@@ -34,7 +34,6 @@ printf " %s\n" $LATEST_GO_VERSION
 
 if [[ $LATEST_GO_VERSION == $LATEST_GOENV_DEFINITION ]]; then
     echo "latest goenv definition ($LATEST_GOENV_DEFINITION) matches latest Go version ($LATEST_GO_VERSION)"
-    export NEW_VERSION=false
     exit 0
 fi
 
@@ -44,7 +43,6 @@ EXISTS=$(git branch -r -l 'origin*' | sed -E -e 's/^[^\/]+\///g' -e 's/HEAD.+//'
 
 if [[ -n $EXISTS ]]; then
     echo "A PR already exists on branch $BRANCH_NAME for the latest Go version ($LATEST_GO_VERSION)"
-    export NEW_VERSION=false
     exit 0
 fi
 
@@ -123,12 +121,12 @@ git push -u origin $BRANCH_NAME
 
 echo "Creating Pull Request..."
 
-gh pr create -B master --title "$COMMIT_MSG" --body 'Created by Github action automation'
+gh pr create -B master \
+    -t "$COMMIT_MSG" \
+    -b "This adds the Go Definitions for version $LATEST_GO_VERSION.\n\nCreated by Github action automation" \
+    -r syndbg,ChronosMasterOfAllTime
 
 echo 'All done!'
 
 # All done, reset PATH
 PATH=$OLD_PATH
-
-# export CREATED_BRANCH_NAME=$BRANCH_NAME
-# export NEW_VERSION=true

--- a/scripts/latest_version.sh
+++ b/scripts/latest_version.sh
@@ -123,7 +123,7 @@ git push -u origin $BRANCH_NAME
 
 echo "Creating Pull Request..."
 
-gh pr create -B master -H $BRANCH_NAME --title "$COMMIT_MSG" --body 'Created by Github action automation'
+gh pr create -B master --title "$COMMIT_MSG" --body 'Created by Github action automation'
 
 echo 'All done!'
 

--- a/scripts/latest_version.sh
+++ b/scripts/latest_version.sh
@@ -113,16 +113,22 @@ printf " done\n"
 
 echo "Committing changes..."
 
-git commit -am "[goenv-bot]: Add $LATEST_GO_VERSION definition to goenv"
+COMMIT_MSG="[goenv-bot]: Add $LATEST_GO_VERSION definition to goenv"
+
+git commit -am "$COMMIT_MSG"
 
 echo "Pushing to origin..."
 
 git push -u origin $BRANCH_NAME
+
+echo "Creating Pull Request..."
+
+gh pr create -B master -H $BRANCH_NAME --title "$COMMIT_MSG" --body 'Created by Github action automation'
 
 echo 'All done!'
 
 # All done, reset PATH
 PATH=$OLD_PATH
 
-export CREATED_BRANCH_NAME=$BRANCH_NAME
-export NEW_VERSION=true
+# export CREATED_BRANCH_NAME=$BRANCH_NAME
+# export NEW_VERSION=true

--- a/scripts/latest_version.sh
+++ b/scripts/latest_version.sh
@@ -19,93 +19,102 @@ latest_includes_unstable_version() {
     definitions | grep -ioE "^$1\\.?([0-9]+|beta[0-9]+|rc[0-9]+)?$" | tail -1
 }
 
-printf "fetching latest goenv definition..."
+capitalize() {
+    printf '%s' "$1" | head -c 1 | tr [:lower:] [:upper:]
+    printf '%s' "$1" | tail -c '+2'
+}
 
-LATEST_GOENV_DEFINITION=$(latest_includes_unstable_version "[0-9]\\.[0-9]+")
+BRANCH_NAME="goenv_bot_add"
 
-printf " %s\n" $LATEST_GOENV_DEFINITION
+while read LATEST_GO_DEFINITION; do
+    printf "fetching latest go version..."
 
-printf "fetching latest go version..."
+    LATEST_GO_VERSION=$(echo $LATEST_GO_DEFINITION | jq '.version' | sed -e 's/go//' -e 's/\"//g')
 
-LATEST_GO_DEFINITIONS=$(curl -s "https://go.dev/dl/?mode=json&include=all" | jq '.[0]')
-LATEST_GO_VERSION=$(echo $LATEST_GO_DEFINITIONS | jq '.version' | sed -e 's/go//' -e 's/\"//g')
+    printf " %s\n" $LATEST_GO_VERSION
 
-printf " %s\n" $LATEST_GO_VERSION
+    printf "fetching latest goenv definition..."
 
-if [[ $LATEST_GO_VERSION == $LATEST_GOENV_DEFINITION ]]; then
-    echo "latest goenv definition ($LATEST_GOENV_DEFINITION) matches latest Go version ($LATEST_GO_VERSION)"
-    exit 0
-fi
+    LATEST_GOENV_DEFINITION=$(latest_includes_unstable_version $(echo $LATEST_GO_VERSION | sed -r 's/^([0-9]+\.[0-9]+)(\.[0-9]+)?$/\1/' | sed s/\\./\\\\./))
 
-BRANCH_NAME="goenv_bot_add_$LATEST_GO_VERSION"
+    printf " %s\n" $LATEST_GOENV_DEFINITION
+
+    if [[ $LATEST_GO_VERSION == $LATEST_GOENV_DEFINITION ]]; then
+        echo "latest goenv definition ($LATEST_GOENV_DEFINITION) matches latest Go version ($LATEST_GO_VERSION)"
+        continue
+    fi
+
+    printf "Creating new definitions for $LATEST_GO_VERSION..."
+
+    BRANCH_NAME="${BRANCH_NAME}_${LATEST_GO_VERSION}"
+
+    echo $BRANCH_NAME
+
+    GO_BUILD_DEFINITION_FILE=$GO_BUILD_DIR/share/go-build/$LATEST_GO_VERSION
+
+    LATEST_FILE_LIST=$(echo $LATEST_GO_DEFINITION | jq -c '.files[] | select(.os == "darwin" or .os == "linux" or .os == "freebsd") | select(.arch == "386" or .arch == "amd64" or .arch == "armv6l" or .arch == "arm64") | select(.kind == "archive")')
+
+    echo $LATEST_FILE_LIST | jq -c '.' | while read FILE_DATA; do
+        FILENAME=$(echo $FILE_DATA | jq -r '.filename')
+        SHA256=$(echo $FILE_DATA | jq -r '.sha256')
+        OS=$(echo $FILE_DATA | jq -r '.os')
+        OS_TITLE_CASE=$(capitalize $OS)
+        ARCH=$(echo $FILE_DATA | jq -r '.arch')
+
+        case $OS in
+        darwin) ;;
+        linux) ;;
+        freebsd)
+            OS="bsd"
+            ;;
+        *)
+            echo "$OS is not valid"
+            continue
+            ;;
+        esac
+
+        case $ARCH in
+        386)
+            ARCH="32bit"
+            ;;
+        amd64)
+            ARCH="64bit"
+            ;;
+        arm64)
+            if [[ $OS == "linux" ]]; then
+                ARCH="arm_64bit"
+            else
+                ARCH="arm"
+            fi
+            ;;
+        armv6l)
+            ARCH="arm"
+            ;;
+        *)
+            echo "$ARCH is not valid"
+            continue
+            ;;
+        esac
+
+        # Version file pattern
+        # install_{OS}_{ARCH} "Go {OS_TITLE_CASE} {ARCH} {VERSION}" "{FILENAME}#{FILE_SHA256}"
+        printf 'install_%s_%s "Go %s %s %s" "%s#%s"\n\n' $OS $ARCH $OS_TITLE_CASE "$(echo $ARCH | sed -e 's/_/ /')" $LATEST_GO_VERSION $FILENAME $SHA256 >>$GO_BUILD_DEFINITION_FILE
+    done
+
+    LATEST_GO_VERSIONS+=($LATEST_GO_VERSION)
+
+done <<<"$(curl -s 'https://go.dev/dl/?mode=json' | jq -c '.[]')"
 
 EXISTS=$(git branch -r -l 'origin*' | sed -E -e 's/^[^\/]+\///g' -e 's/HEAD.+//' | grep "$BRANCH_NAME")
 
 if [[ -n $EXISTS ]]; then
-    echo "A PR already exists on branch $BRANCH_NAME for the latest Go version ($LATEST_GO_VERSION)"
+    echo "A PR already exists on branch $BRANCH_NAME for the latest Go version(s) (${LATEST_GO_VERSIONS[@]})"
     exit 0
 fi
 
 echo "checking out new Git branch $BRANCH_NAME..."
 
 git checkout -b $BRANCH_NAME
-
-printf "Creating new definitions for $LATEST_GO_VERSION..."
-
-capitalize() {
-    printf '%s' "$1" | head -c 1 | tr [:lower:] [:upper:]
-    printf '%s' "$1" | tail -c '+2'
-}
-
-GO_BUILD_DEFINITION_FILE=$GO_BUILD_DIR/share/go-build/$LATEST_GO_VERSION
-
-LATEST_FILE_LIST=$(echo $LATEST_GO_DEFINITIONS | jq -c '.files[] | select(.os == "darwin" or .os == "linux" or .os == "freebsd") | select(.arch == "386" or .arch == "amd64" or .arch == "armv6l" or .arch == "arm64") | select(.kind == "archive")')
-
-echo $LATEST_FILE_LIST | jq -c '.' | while read FILE_DATA; do
-    FILENAME=$(echo $FILE_DATA | jq -r '.filename')
-    SHA256=$(echo $FILE_DATA | jq -r '.sha256')
-    OS=$(echo $FILE_DATA | jq -r '.os')
-    OS_TITLE_CASE=$(capitalize $OS)
-    ARCH=$(echo $FILE_DATA | jq -r '.arch')
-
-    case $OS in
-    darwin) ;;
-    linux) ;;
-    freebsd)
-        OS="bsd"
-        ;;
-    *)
-        echo "$OS is not valid"
-        ;;
-    esac
-
-    case $ARCH in
-    386)
-        ARCH="32bit"
-        ;;
-    amd64)
-        ARCH="64bit"
-        ;;
-    arm64)
-        if [[ $OS == "linux" ]]; then
-            ARCH="arm_64bit"
-        else
-            ARCH="arm"
-        fi
-        ;;
-    armv6l)
-        ARCH="arm"
-        ;;
-    *)
-        echo "$ARCH is not valid"
-        exit 1
-        ;;
-    esac
-
-    # Version file pattern
-    # install_{OS}_{ARCH} "Go {OS_TITLE_CASE} {ARCH} {VERSION}" "{FILENAME}#{FILE_SHA256}"
-    printf 'install_%s_%s "Go %s %s %s" "%s#%s"\n\n' $OS $ARCH $OS_TITLE_CASE "$(echo $ARCH | sed -e 's/_/ /')" $LATEST_GO_VERSION $FILENAME $SHA256 >>$GO_BUILD_DEFINITION_FILE
-done
 
 printf " done\n"
 

--- a/scripts/latest_version.sh
+++ b/scripts/latest_version.sh
@@ -25,7 +25,7 @@ capitalize() {
     printf '%s' "$1" | tail -c '+2'
 }
 
-BRANCH_NAME="goenv_bot_add"
+BRANCH_NAME_PREFIX="goenv_bot_add"
 
 while read LATEST_GO_DEFINITION; do
     printf "fetching latest go version..."
@@ -47,9 +47,7 @@ while read LATEST_GO_DEFINITION; do
 
     printf "Creating new definitions for $LATEST_GO_VERSION..."
 
-    BRANCH_NAME="${BRANCH_NAME}_${LATEST_GO_VERSION}"
-
-    echo $BRANCH_NAME
+    BRANCH_NAME="${BRANCH_NAME_PREFIX}_${LATEST_GO_VERSION}"
 
     GO_BUILD_DEFINITION_FILE=$GO_DEFINITIONS_DIR/$LATEST_GO_VERSION
 
@@ -106,6 +104,9 @@ while read LATEST_GO_DEFINITION; do
 
 done <<<"$(curl -s 'https://go.dev/dl/?mode=json' | jq -c '.[]')"
 
+git config --global user.name "${GITHUB_ACTOR}"
+git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
 EXISTS=$(git branch -r -l 'origin*' | sed -E -e 's/^[^\/]+\///g' -e 's/HEAD.+//' | grep "$BRANCH_NAME")
 
 if [[ -n $EXISTS ]]; then
@@ -115,7 +116,7 @@ fi
 
 echo "checking out new Git branch $BRANCH_NAME..."
 
-git checkout -b $BRANCH_NAME
+git switch -c $BRANCH_NAME master
 
 printf " done\n"
 
@@ -136,8 +137,7 @@ echo "Creating Pull Request..."
 gh pr create -B master \
     -t "$COMMIT_MSG" \
     -b "This adds the Go Definitions for version ${LATEST_GO_VERSIONS[@]}. 
-    Created by Github action automation" \
-    -r syndbg,ChronosMasterOfAllTime
+    Created by Github action automation"
 
 echo 'All done!'
 

--- a/scripts/latest_version.sh
+++ b/scripts/latest_version.sh
@@ -2,6 +2,7 @@
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
 GO_BUILD_DIR=$GIT_ROOT/plugins/go-build
+GO_DEFINITIONS_DIR=$GO_BUILD_DIR/share/go-build
 
 OLD_PATH=$PATH
 
@@ -50,7 +51,7 @@ while read LATEST_GO_DEFINITION; do
 
     echo $BRANCH_NAME
 
-    GO_BUILD_DEFINITION_FILE=$GO_BUILD_DIR/share/go-build/$LATEST_GO_VERSION
+    GO_BUILD_DEFINITION_FILE=$GO_DEFINITIONS_DIR/$LATEST_GO_VERSION
 
     LATEST_FILE_LIST=$(echo $LATEST_GO_DEFINITION | jq -c '.files[] | select(.os == "darwin" or .os == "linux" or .os == "freebsd") | select(.arch == "386" or .arch == "amd64" or .arch == "armv6l" or .arch == "arm64") | select(.kind == "archive")')
 
@@ -120,9 +121,11 @@ printf " done\n"
 
 echo "Committing changes..."
 
-COMMIT_MSG="[goenv-bot]: Add $LATEST_GO_VERSION definition to goenv"
+COMMIT_MSG="[goenv-bot]: Add ${LATEST_GO_VERSIONS[@]} definition to goenv"
 
-git commit -am "$COMMIT_MSG"
+git add $GO_DEFINITIONS_DIR
+
+git commit -m "$COMMIT_MSG"
 
 echo "Pushing to origin..."
 
@@ -132,7 +135,7 @@ echo "Creating Pull Request..."
 
 gh pr create -B master \
     -t "$COMMIT_MSG" \
-    -b "This adds the Go Definitions for version $LATEST_GO_VERSION. 
+    -b "This adds the Go Definitions for version ${LATEST_GO_VERSIONS[@]}. 
     Created by Github action automation" \
     -r syndbg,ChronosMasterOfAllTime
 

--- a/scripts/latest_version.sh
+++ b/scripts/latest_version.sh
@@ -38,7 +38,7 @@ if [[ $LATEST_GO_VERSION == $LATEST_GOENV_DEFINITION ]]; then
     exit 0
 fi
 
-BRANCH_NAME="add_$LATEST_GO_VERSION"
+BRANCH_NAME="goenv_bot_add_$LATEST_GO_VERSION"
 
 EXISTS=$(git branch -r -l 'origin*' | sed -E -e 's/^[^\/]+\///g' -e 's/HEAD.+//' | grep "$BRANCH_NAME")
 

--- a/scripts/latest_version.sh
+++ b/scripts/latest_version.sh
@@ -134,7 +134,7 @@ git push -u origin $BRANCH_NAME
 
 echo "Creating Pull Request..."
 
-gh pr create -B master \
+gh pr create -R syndbg/goenv -B master \
     -t "$COMMIT_MSG" \
     -b "This adds the Go Definitions for version ${LATEST_GO_VERSIONS[@]}. 
     Created by Github action automation"

--- a/scripts/latest_version.sh
+++ b/scripts/latest_version.sh
@@ -123,7 +123,8 @@ echo "Creating Pull Request..."
 
 gh pr create -B master \
     -t "$COMMIT_MSG" \
-    -b "This adds the Go Definitions for version $LATEST_GO_VERSION.\n\nCreated by Github action automation" \
+    -b "This adds the Go Definitions for version $LATEST_GO_VERSION. 
+    Created by Github action automation" \
     -r syndbg,ChronosMasterOfAllTime
 
 echo 'All done!'


### PR DESCRIPTION
The goal of this PR is to address the idea referenced in #253. Theere will be an automatic PR that gets opened if the following conditions are satisfied:

- the latest go version doesn't already have a definition file
- another PR doesn't already exist

The Action will run once a day. 

Script has been tested for the above scenarios.

The downside is it will require we create an access token and add it to the secrets for this repo.

@detro @syndbg  any thoughts as well? This will keep any sub dependencies out of goenv and isolated to this action