### PR TITLE
Add support for go 1.19.6 and 1.20.1

### DIFF
--- a/plugins/go-build/share/go-build/1.19.6
+++ b/plugins/go-build/share/go-build/1.19.6
@@ -1,0 +1,15 @@
+install_darwin_64bit "Go Darwin 64bit 1.19.6" "go1.19.6.darwin-amd64.tar.gz#108a3cd27b7dff5a8b3540d3bab0aa04d16814babc85625b183f2a1217af88d0"
+
+install_darwin_arm "Go Darwin arm 1.19.6" "go1.19.6.darwin-arm64.tar.gz#dfbf3e4686dd7fee7a9c0223c52b124c1af5f02508baf07e1e59489cd9df2a90"
+
+install_bsd_32bit "Go Freebsd 32bit 1.19.6" "go1.19.6.freebsd-386.tar.gz#6b20260968ed6ccd3d48b39aaee7816e44c8c5ccc341c20e6a46327d051667c2"
+
+install_bsd_64bit "Go Freebsd 64bit 1.19.6" "go1.19.6.freebsd-amd64.tar.gz#f4b432ebe462a6edd6131e94360b9f0fb3b8136bba39caeacb4aa22a89ba1dd8"
+
+install_linux_32bit "Go Linux 32bit 1.19.6" "go1.19.6.linux-386.tar.gz#da4546cc516ae88698e8643d6d22fe1465b44dd49fc36abb34d53a93c19581ad"
+
+install_linux_64bit "Go Linux 64bit 1.19.6" "go1.19.6.linux-amd64.tar.gz#e3410c676ced327aec928303fef11385702a5562fd19d9a1750d5a2979763c3d"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.19.6" "go1.19.6.linux-arm64.tar.gz#e4d63c933a68e5fad07cab9d12c5c1610ce4810832d47c44314c3246f511ac4f"
+
+install_linux_arm "Go Linux arm 1.19.6" "go1.19.6.linux-armv6l.tar.gz#1f5900567595366fbb3b9ea02cee8ea67ac4b87234fb246549b902cde1013821"

--- a/plugins/go-build/share/go-build/1.20.1
+++ b/plugins/go-build/share/go-build/1.20.1
@@ -1,0 +1,15 @@
+install_darwin_64bit "Go Darwin 64bit 1.20.1" "go1.20.1.darwin-amd64.tar.gz#a300a45e801ab459f3008aae5bb9efbe9a6de9bcd12388f5ca9bbd14f70236de"
+
+install_darwin_arm "Go Darwin arm 1.20.1" "go1.20.1.darwin-arm64.tar.gz#f1a8e06c7f1ba1c008313577f3f58132eb166a41ceb95ce6e9af30bc5a3efca4"
+
+install_bsd_32bit "Go Freebsd 32bit 1.20.1" "go1.20.1.freebsd-386.tar.gz#57d80349dc4fbf692f8cd85a5971f97841aedafcf211e367e59d3ae812292660"
+
+install_bsd_64bit "Go Freebsd 64bit 1.20.1" "go1.20.1.freebsd-amd64.tar.gz#6e124d54d5850a15fdb15754f782986f06af23c5ddb6690849417b9c74f05f98"
+
+install_linux_32bit "Go Linux 32bit 1.20.1" "go1.20.1.linux-386.tar.gz#3a7345036ebd92455b653e4b4f6aaf4f7e1f91f4ced33b23d7059159cec5f4d7"
+
+install_linux_64bit "Go Linux 64bit 1.20.1" "go1.20.1.linux-amd64.tar.gz#000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02"
+
+install_linux_arm_64bit "Go Linux arm 64bit 1.20.1" "go1.20.1.linux-arm64.tar.gz#5e5e2926733595e6f3c5b5ad1089afac11c1490351855e87849d0e7702b1ec2e"
+
+install_linux_arm "Go Linux arm 1.20.1" "go1.20.1.linux-armv6l.tar.gz#e4edc05558ab3657ba3dddb909209463cee38df9c1996893dd08cde274915003"


### PR DESCRIPTION
There were some pretty big CVEs so expect a lot of people to be upgrading to 1.19.6 and 1.20.1 soon.

See: https://go.dev/dl/#go1.20